### PR TITLE
Adding VCF output capability; plus filtering to non-ref variants only after subsetting samples

### DIFF
--- a/entire_vds_pipeline.py
+++ b/entire_vds_pipeline.py
@@ -488,7 +488,7 @@ if not args.skip_vep:
 
     input_path = vep_output_vds
 
-# write out new vcf (with new sample ids and subset
+# write out new vcf (after sample id remapping and subsetting if requested above)
 if args.export_vcf:
     logger.info("Writing out to VCF...")
     if not args.skip_vep:


### PR DESCRIPTION
VCF output capability has been requested from collaborators and is necessary for Mike to run the final step in the seqr upload pipeline to make the samples available in the UI. The pipeline currently needs to match sample IDs in the VCF with what's in seqr; and after remapping sample IDs in the VDS (and, by extension, the elasticsearch database) we need to provide that script with a VCF with the remapped sample IDs.

Filtering to non-ref variants will reduce the elasticsearch table sizes.