### PR TITLE
Use project argument in run script scripts

### DIFF
--- a/gcloud_dataproc/run_script.py
+++ b/gcloud_dataproc/run_script.py
@@ -26,7 +26,7 @@ script_args = " ".join(['"%s"' % arg for arg in unparsed_args])
 
 run((
    "python gcloud_dataproc/create_cluster_without_VEP.py "
-   "--project=seqr-project "
+   "--project=%(project)s "
    "%(cluster_name)s 2 24") % locals())
 
 
@@ -38,5 +38,5 @@ if "-h" in sys.argv or "--help" in sys.argv:
 run((
     "time ./gcloud_dataproc/submit.py "
     "--cluster %(cluster_name)s "
-    "--project seqr-project "
+    "--project %(project)s "
     "%(script)s %(script_args)s") % locals())

--- a/gcloud_dataproc/run_script_GRCh37.py
+++ b/gcloud_dataproc/run_script_GRCh37.py
@@ -30,7 +30,7 @@ os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 
 run((
    "python gcloud_dataproc/create_cluster_GRCh37.py "
-   "--project=seqr-project "
+   "--project=%(project)s "
    "%(cluster_name)s 2 24") % locals())
 
 
@@ -42,5 +42,5 @@ if "-h" in sys.argv or "--help" in sys.argv:
 run((
     "time ./gcloud_dataproc/submit.py "
     "--cluster %(cluster_name)s "
-    "--project seqr-project "
+    "--project %(project)s "
     "%(script)s %(script_args)s") % locals())

--- a/gcloud_dataproc/run_script_GRCh38.py
+++ b/gcloud_dataproc/run_script_GRCh38.py
@@ -30,7 +30,7 @@ os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 
 run((
    "python gcloud_dataproc/create_cluster_GRCh38.py "
-   "--project=seqr-project "
+   "--project=%(project)s "
    "%(cluster_name)s 2 24") % locals())
 
 
@@ -42,5 +42,5 @@ if "-h" in sys.argv or "--help" in sys.argv:
 run((
     "time ./gcloud_dataproc/submit.py "
     "--cluster %(cluster_name)s "
-    "--project seqr-project "
+    "--project %(project)s "
     "%(script)s %(script_args)s") % locals())


### PR DESCRIPTION
Currently, run_script.py, run_script_GRCh37.py, and run_script_GRCh38.py all accept a project argument but ignore it and pass "seqr-project" as the project argument to their create cluster and submit scripts.