### PR TITLE
Added transcript consequence mapping for clinvar track

### DIFF
--- a/hail_scripts/load_clinvar_to_es_pipeline.py
+++ b/hail_scripts/load_clinvar_to_es_pipeline.py
@@ -9,7 +9,7 @@ from hail_scripts.utils.computed_fields import get_expr_for_contig, get_expr_for
     get_expr_for_alt_allele, get_expr_for_variant_id, get_expr_for_worst_transcript_consequence_annotations_struct, \
     get_expr_for_xpos, get_expr_for_vep_gene_ids_set, get_expr_for_vep_transcript_ids_set, \
     get_expr_for_vep_sorted_transcript_consequences_array, get_expr_for_vep_protein_domains_set, \
-    get_expr_for_vep_consequence_terms_set
+    get_expr_for_vep_consequence_terms_set, get_expr_for_vep_transcript_id_to_consequence_map
 from hail_scripts.utils.elasticsearch_client import ElasticsearchClient
 
 p = argparse.ArgumentParser()
@@ -80,6 +80,7 @@ computed_annotation_exprs = [
     "va.sortedTranscriptConsequences = %s" % get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep"),
     "va.transcriptConsequenceTerms = %s" % get_expr_for_vep_consequence_terms_set(vep_transcript_consequences_root="va.sortedTranscriptConsequences"),
     "va.transcriptIds = %s" % get_expr_for_vep_transcript_ids_set(vep_transcript_consequences_root="va.sortedTranscriptConsequences"),
+    "va.transcriptIdToConsequenceMap = %s" % get_expr_for_vep_transcript_id_to_consequence_map(vep_transcript_consequences_root="va.sortedTranscriptConsequences"),
     "va.geneIds = %s" % get_expr_for_vep_gene_ids_set(vep_transcript_consequences_root="va.sortedTranscriptConsequences", exclude_upstream_downstream_genes=True),
     #"va.codingGeneIds = %s" % get_expr_for_vep_gene_ids_set(vep_transcript_consequences_root="va.sortedTranscriptConsequences", only_coding_genes=True, exclude_upstream_downstream_genes=True),
     "va.mainTranscript = %s" % get_expr_for_worst_transcript_consequence_annotations_struct("va.sortedTranscriptConsequences"),

--- a/hail_scripts/utils/computed_fields.py
+++ b/hail_scripts/utils/computed_fields.py
@@ -348,10 +348,11 @@ def get_expr_for_vep_transcript_id_to_consequence_map(vep_transcript_consequence
     return """[
         '{',
             %(vep_transcript_consequences_root)s
-                .map( x => ['"', x.transcript_id, '": "', x.major_consequence, '"'] )
-                .mkString(","),
+                .map( x =>  
+                    ['"', x.transcript_id, '": "', x.major_consequence, '"'].mkString("") 
+                ).mkString(", "),
         '}'
-    ].mkString('')
+    ].mkString("")
     """ % locals()
 
 

--- a/hail_scripts/utils/computed_fields.py
+++ b/hail_scripts/utils/computed_fields.py
@@ -344,6 +344,17 @@ def get_expr_for_vep_protein_domains_set(vep_transcript_consequences_root="va.ve
         .flatten.toSet""" % locals()
 
 
+def get_expr_for_vep_transcript_id_to_consequence_map(vep_transcript_consequences_root="va.vep.transcript_consequences"):
+    return """[
+        '{',
+            %(vep_transcript_consequences_root)s
+                .map( x => ['"', x.transcript_id, '": "', x.major_consequence, '"'] )
+                .mkString(","),
+        '}'
+    ].mkString('')
+    """ % locals()
+
+
 def get_expr_for_contig(field_prefix="v."):
     """Normalized contig name"""
     return field_prefix+'contig.replace("chr", "")'


### PR DESCRIPTION
Added `transcript_id_to_consequence_json` field with values like:
```
{"ENST00000263253": "missense_variant", "ENST00000634787": "upstream_gene_variant", "ENST00000637592": "downstream_gene_variant"}
```

The full clinvar schema is now:
![image](https://user-images.githubusercontent.com/6240170/42912677-a6ad7940-8abe-11e8-803c-6105d6d1ba46.png)
