### PR TITLE
Store map of gene ID to major consequence for ClinVar variants

### DIFF
--- a/hail_scripts/v02/load_clinvar_to_es.py
+++ b/hail_scripts/v02/load_clinvar_to_es.py
@@ -43,7 +43,7 @@ mt = download_and_import_latest_clinvar_vcf(args.genome_version)
 print(dict(mt.globals.value))
 
 print("\n=== Running VEP ===")
-mt = hl.vep(mt, "/vep/vep-gcloud.properties", name="vep", block_size=1000)
+mt = hl.vep(mt, "file:///vep/vep85-gcloud.json", name="vep", block_size=1000)
 
 print("\n=== Processing ===")
 mt = mt.annotate_rows(

--- a/hail_scripts/v02/utils/computed_fields/vep.py
+++ b/hail_scripts/v02/utils/computed_fields/vep.py
@@ -187,6 +187,22 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root, include_codi
     return result
 
 
+def get_expr_for_vep_gene_id_to_consequence_map(vep_sorted_transcript_consequences_root, gene_ids):
+    # Manually build string because hl.json encodes a dictionary as [{ key: ..., value: ... }, ...]
+    return (
+        "{"
+        + hl.delimit(
+            gene_ids.map(
+                lambda gene_id: hl.bind(
+                    lambda worst_consequence_in_gene: '"' + gene_id + '":"' + worst_consequence_in_gene.major_consequence + '"',
+                    vep_sorted_transcript_consequences_root.find(lambda c: c.gene_id == gene_id)
+                )
+            )
+        )
+        + "}"
+    )
+
+
 def get_expr_for_vep_transcript_id_to_consequence_map(vep_transcript_consequences_root):
     # Manually build string because hl.json encodes a dictionary as [{ key: ..., value: ... }, ...]
     return (


### PR DESCRIPTION
gnomAD needs to be able to show the worst consequence of a variant in a specific gene. Add a map of gene ID to consequence similar to the map of transcript ID to consequence.

Also, Hail's expected format for VEP configuration has changed.