### PR TITLE
fix multiallelics

### DIFF
--- a/hail_scripts/v01/convert_vcf_to_vds.py
+++ b/hail_scripts/v01/convert_vcf_to_vds.py
@@ -33,10 +33,8 @@ for vcf_path in args.vcf_path:
 
     print("\n==> split_multi")
     vds = vds.annotate_variants_expr("va.originalAltAlleles=%s" % get_expr_for_orig_alt_alleles_set())
-    if vds.was_split():
-        vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')
-    else:
-        vds = vds.split_multi()
+
+    vds = vds.split_multi()
 
     print("")
     pprint(vds.variant_schema)

--- a/hail_scripts/v01/run_vep.py
+++ b/hail_scripts/v01/run_vep.py
@@ -41,10 +41,8 @@ if vds.num_partitions() < 50:
     vds = vds.repartition(10000)
 
 vds = vds.annotate_variants_expr("va.originalAltAlleles=%s" % get_expr_for_orig_alt_alleles_set())
-if vds.was_split():
-    vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')
-else:
-    vds = vds.split_multi()
+
+vds = vds.split_multi()
 
 #vds = vds.filter_alleles('v.altAlleles[aIndex-1].isStar()', keep=False)
 filter_interval = "1-MT"

--- a/hail_scripts/v01/utils/add_clinvar.py
+++ b/hail_scripts/v01/utils/add_clinvar.py
@@ -134,10 +134,7 @@ def download_and_import_latest_clinvar_vcf(hail_context, genome_version, subset=
     vds = vds.annotate_global_expr('global.version = "{}"'.format(clinvar_release_date))
 
     # handle multi-allelics
-    if vds.was_split():
-        vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')
-    else:
-        vds = vds.split_multi()
+    vds = vds.split_multi()
 
     # for some reason, this additional filter is necessary to avoid
     #  IllegalArgumentException: requirement failed: called altAllele on a non-biallelic variant

--- a/hail_scripts/v01/utils/vds_utils.py
+++ b/hail_scripts/v01/utils/vds_utils.py
@@ -78,10 +78,8 @@ def read_in_dataset(hc, input_path, dataset_type="VARIANTS", filter_interval=Non
 
     if dataset_type == "VARIANTS":
         vds = vds.annotate_variants_expr("va.originalAltAlleles=%s" % get_expr_for_orig_alt_alleles_set())
-        if vds.was_split():
-            vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')  # isDefined(va.wasSplit)
-        else:
-            vds = vds.split_multi()
+
+        vds = vds.split_multi()
 
         if not skip_summary:
             logger.info("Callset stats:")
@@ -89,7 +87,9 @@ def read_in_dataset(hc, input_path, dataset_type="VARIANTS", filter_interval=Non
             pprint(summary)
             total_variants = summary.variants
     elif dataset_type == "SV":
-        vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')
+
+        #vds = vds.annotate_variants_expr('va.aIndex = 1, va.wasSplit = false')  # this line assumes there are no multiallelics
+
         if not skip_summary:
             _, total_variants = vds.count()
     else:


### PR DESCRIPTION
remove multiallelic handling code which was originally suggested as a workaround for the hail issue where va.aIndex and va.wasSplit can still be undefined after calling vds.split_multi() when a vds had 0 multiallelics. When this code is applied more than once to a callset, it causes another bug where info fields aren't split properly. 