### PR TITLE
Check for Elasticsearch package before installing

### DIFF
--- a/hail_scripts/shared/elasticsearch_client.py
+++ b/hail_scripts/shared/elasticsearch_client.py
@@ -1,13 +1,15 @@
-import os
-os.system("pip install elasticsearch")
-
 import datetime
 import inspect
 import logging
 import time
 from pprint import pformat
 
-import elasticsearch
+try:
+    import elasticsearch
+except ImportError:
+    import os
+    os.system("pip install elasticsearch")
+    import elasticsearch
 
 
 handlers = set(logging.root.handlers)


### PR DESCRIPTION
Currently, importing `ElasticsearchClient` automatically runs `pip install elasticsearch`. However, this isn't necessary if `elasticsearch` is already installed (such as when starting a cluster with `cloudtools start --packages elasticsearch`).

With this change, `ElasticsearchClient` will attempt to import `elasticsearch` first and only run `pip install` if the import fails.