### PR TITLE
Add function to get variant IDs of original alt alleles in a split variant

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/variant_id.py
+++ b/hail_scripts/v02/utils/computed_fields/variant_id.py
@@ -20,6 +20,15 @@ def get_expr_for_contig_number(table):
     )
 
 
+def get_expr_for_original_alt_alleles_set(split_variant):
+    """Compute variant id for each original alt allele in a variant split with hl.split_multi"""
+    return hl.set(
+        split_variant.old_alleles[1:].map(
+            lambda alt: get_expr_for_variant_id(hl.min_rep(split_variant.old_locus, [split_variant.old_alleles[0], alt]))
+        )
+    )
+
+
 def get_expr_for_ref_allele(table):
     return table.alleles[0]
 


### PR DESCRIPTION
The Hail 0.2 equivalent of:

https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/cd9ebb47ce435693e98753d03688ef6b3598b102/hail_scripts/v01/utils/computed_fields.py#L352-L355