### PR TITLE
add --dont-export-to-elasticsearch-until-the-end and --use-nested-objects-for-vep options

### DIFF
--- a/gcloud_dataproc/submit.py
+++ b/gcloud_dataproc/submit.py
@@ -50,11 +50,11 @@ if args.run_locally:
 
     hail_home = args.hail_home
     spark_home = args.spark_home
-    cpu_limit = args.cpu_limit
+    cpu_limit_arg = ("--master local[%s]" % args.cpu_limit) if args.cpu_limit else ""
     driver_memory = args.driver_memory
     executor_memory = args.executor_memory
     command = """%(spark_home)s/bin/spark-submit \
-        --master local[%(cpu_limit)s] \
+        %(cpu_limit_arg)s \
         --driver-memory %(driver_memory)s \
         --executor-memory %(executor_memory)s \
         --conf spark.driver.extraJavaOptions=-Xss4M \

--- a/gcloud_dataproc/submit.py
+++ b/gcloud_dataproc/submit.py
@@ -11,6 +11,7 @@ p.add_argument("-c", "--cluster", default="no-vep")
 p.add_argument("--run-locally", action="store_true", help="Run using a local hail install instead of submitting to dataproc. Assumes 'spark-submit' is on $PATH.")
 p.add_argument("--hail-home", default=os.environ.get("HAIL_HOME"), help="The local hail directory (default: $HAIL_HOME). Required for --run-locally")
 p.add_argument("--spark-home", default=os.environ.get("SPARK_HOME"), help="The local spark directory (default: $SPARK_HOME). Required for --run-locally")
+p.add_argument("--cpu-limit", help="How many CPUs to use when running locally. Defaults to all available CPUs.", type=int)
 p.add_argument("--driver-memory", help="Spark driver memory limit when running locally", default="5G")
 p.add_argument("--executor-memory", help="Spark executor memory limit when running locally", default="5G")
 p.add_argument("script")
@@ -49,9 +50,11 @@ if args.run_locally:
 
     hail_home = args.hail_home
     spark_home = args.spark_home
+    cpu_limit = args.cpu_limit
     driver_memory = args.driver_memory
     executor_memory = args.executor_memory
     command = """%(spark_home)s/bin/spark-submit \
+        --master local[%(cpu_limit)s] \
         --driver-memory %(driver_memory)s \
         --executor-memory %(executor_memory)s \
         --conf spark.driver.extraJavaOptions=-Xss4M \

--- a/hail_scripts/v01/utils/computed_fields.py
+++ b/hail_scripts/v01/utils/computed_fields.py
@@ -46,7 +46,7 @@ CONSEQUENCE_TERM_RANK_LOOKUP = (
 ).replace("'", '"')
 
 
-def get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep", include_coding_annotations=True):
+def get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep", include_coding_annotations=True, add_transcript_rank=True):
     """Sort transcripts by 3 properties:
 
         1. coding > non-coding
@@ -68,6 +68,9 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep", inc
     Args:
         vep_root (string): root path of the VEP struct in the VDS
         include_coding_annotations (bool): if True, fields relevant to protein-coding variants will be included
+        add_transcript_rank (bool): if True, a 'transcript_rank' field will be added to each transcript Struct which
+            records the transcript's ranking based on the above sort order.
+
     """
 
     coding_transcript_consequences = """
@@ -111,8 +114,7 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep", inc
         transcript_consequences = non_coding_transcript_consequences
 
     result = """
-    let CONSEQUENCE_TERM_RANK_LOOKUP = %(CONSEQUENCE_TERM_RANK_LOOKUP)s in
-        %(vep_root)s.transcript_consequences.map(
+    let CONSEQUENCE_TERM_RANK_LOOKUP = %(CONSEQUENCE_TERM_RANK_LOOKUP)s in %(vep_root)s.transcript_consequences.map(
             c => select(c, %(transcript_consequences)s)
         ).map(
             c => merge(
@@ -155,10 +157,19 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root="va.vep", inc
         )
     """ % dict(locals().items()+globals().items())
 
-
     if not include_coding_annotations:
         # for non-coding variants, drop fields here that are hard to exclude in the above code
         result += ".map(c => drop(c, domains, hgvsp))"
+
+    if add_transcript_rank:
+        result = """let processed_transcript_consequences = %(result)s in 
+            range(processed_transcript_consequences.length).map(array_index => 
+                merge(
+                    processed_transcript_consequences[array_index],
+                    { transcript_rank: array_index }
+                )
+            )
+        """ % locals()
 
     return result
 
@@ -329,7 +340,6 @@ def get_expr_for_variant_type():
         else if (v.ref.length > 1) "M"
         else "S"
     """
-    
 
 
 def get_expr_for_contig(field_prefix="v."):
@@ -398,6 +408,7 @@ def get_expr_for_xpos(field_prefix="v.", pos_field="start"):
 def get_expr_for_end_pos(field_prefix="v.", pos_field="start", ref_field="ref"):
     """Compute the end position based on start position and ref allele length"""
     return "%(field_prefix)s%(pos_field)s + %(field_prefix)s%(ref_field)s.length - 1" % locals()
+
 
 def get_expr_for_end_pos_from_info_field(field_prefix="va.", end_field="info.END"):
     """Retrieve the "END" position from the INFO field. This is typically found in VCFs produced by


### PR DESCRIPTION
A new `transcript_rank` field is also computed for every vep annotation. 
It's intended to be used for sorting the transcripts during queries and, for example, only returning the top matching transcript using the inner hits 'sort' and 'size' params  (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-inner-hits.html#_options)