### PR TITLE
Add helpers to precompute browser LoF flags

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/__init__.py
+++ b/hail_scripts/v02/utils/computed_fields/__init__.py
@@ -1,2 +1,3 @@
+from .flags import *
 from .variant_id import *
 from .vep import *

--- a/hail_scripts/v02/utils/computed_fields/flags.py
+++ b/hail_scripts/v02/utils/computed_fields/flags.py
@@ -1,0 +1,17 @@
+import hail as hl
+
+
+def get_expr_for_lc_lof_flag(sortedTranscriptConsequences):
+    """Flag a variant if no LoF annotations are marked HC"""
+    return hl.bind(
+        lambda lof_annotations: (lof_annotations.size() > 0) & lof_annotations.all(lambda csq: csq.lof != "HC"),
+        sortedTranscriptConsequences.filter(lambda csq: csq.lof != ""),
+    )
+
+
+def get_expr_for_loftee_flag_flag(sortedTranscriptConsequences):
+    """Flag a variant if all annotations have LOFTEE flags"""
+    return hl.bind(
+        lambda lof_annotations: (lof_annotations.size() > 0) & lof_annotations.all(lambda csq: csq.lof_flags != ""),
+        sortedTranscriptConsequences.filter(lambda csq: csq.lof != ""),
+    )

--- a/hail_scripts/v02/utils/computed_fields/vep.py
+++ b/hail_scripts/v02/utils/computed_fields/vep.py
@@ -214,6 +214,13 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root, include_codi
                 hgvs=get_expr_for_formatted_hgvs(c),
                 major_consequence_rank=CONSEQUENCE_TERM_RANK_LOOKUP.get(c.major_consequence),
             )
+        )
+        .map(
+            lambda c: hl.cond(
+                (c.major_consequence_rank <= CONSEQUENCE_TERM_RANK_LOOKUP.get("frameshift_variant")) & ((c.lof == "") | hl.is_missing(c.lof)),
+                c.annotate(lof="NC", lof_filter="Non-protein-coding gene"),
+                c,
+            )
         ),
         lambda c: (
             hl.bind(


### PR DESCRIPTION
To avoid having to retrieve all transcript consequences from Elasticsearch, precompute flags which are shown in the browser.

Matching this behavior from gnomad_browser:
https://github.com/macarthur-lab/gnomad_browser/blob/b4ff2705fd540037acc31f234f660b26162f5207/utils.py#L95-L109