### PR TITLE
Add rank field to sorted transcript consequences

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/vep.py
+++ b/hail_scripts/v02/utils/computed_fields/vep.py
@@ -235,7 +235,9 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root, include_codi
         # for non-coding variants, drop fields here that are hard to exclude in the above code
         result = result.map(lambda c: c.drop("domains", "hgvsp"))
 
-    return result
+    return hl.zip_with_index(result).map(
+        lambda csq_with_index: csq_with_index[1].annotate(transcript_rank=csq_with_index[0])
+    )
 
 
 def get_expr_for_vep_gene_id_to_consequence_map(vep_sorted_transcript_consequences_root, gene_ids):


### PR DESCRIPTION
Add `transcript_rank` field to `sortedTranscriptConsequences`. This field contains the consequence's index in the list of all sorted consequences for the variant.