### PR TITLE
Remove original alt alleles function

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/variant_id.py
+++ b/hail_scripts/v02/utils/computed_fields/variant_id.py
@@ -1,5 +1,5 @@
 import hail as hl
-from typing import List
+
 
 def get_expr_for_alt_allele(table:hl.Table) -> hl.str:
     return table.alleles[1]
@@ -20,20 +20,19 @@ def get_expr_for_contig_number(table:hl.Table) -> hl.int:
     )
 
 
-def get_expr_for_variant_ids(table, max_length=None) -> List[hl.str]:
+def get_expr_for_variant_ids(
+    locus: hl.expr.LocusExpression, alleles: hl.expr.ArrayExpression, max_length: int = None
+) -> hl.expr.ArrayExpression:
     """Return a list of variant ids - one for each alt allele in the variant"""
 
     def compute_variant_id(alt):
-        variant_id = get_expr_for_contig(table) + "-" + hl.str(table.locus.position) + "-" + table.alleles[0] + "-" + alt
+        variant_id = locus.contig + "-" + hl.str(locus.position) + "-" + alleles[0] + "-" + alt
         if max_length is not None:
             variant_id = variant_id[:max_length]
         return variant_id
 
-    return table.alleles[1:].map(compute_variant_id)
+    return alleles[1:].map(compute_variant_id)
 
-def get_expr_for_orig_alt_alleles(table, max_length=None):
-    """Return a list of alt-alleles. This can be used for saving original alleles before running hl.split_multi"""
-    return hl.or_missing(hl.len(table.alleles) > 2, get_expr_for_variant_ids(table, max_length=max_length))
 
 def get_expr_for_ref_allele(table):
     return table.alleles[0]

--- a/hail_scripts/v02/utils/hail_utils.py
+++ b/hail_scripts/v02/utils/hail_utils.py
@@ -1,7 +1,7 @@
 import hail as hl
 import logging
 
-from hail_scripts.v02.utils.computed_fields.variant_id import get_expr_for_orig_alt_alleles
+from hail_scripts.v02.utils.computed_fields.variant_id import get_expr_for_variant_ids
 
 logger = logging.getLogger()
 
@@ -71,7 +71,9 @@ def import_vcf(
 
     mt = mt.annotate_globals(sourceFilePath=vcf_path, genomeVersion=genome_version)
 
-    mt = mt.annotate_rows(original_alt_alleles=get_expr_for_orig_alt_alleles(mt))
+    mt = mt.annotate_rows(
+        original_alt_alleles=hl.or_missing(hl.len(mt.alleles) > 2, get_expr_for_variant_ids(mt.locus, mt.alleles))
+    )
     mt = hl.split_multi_hts(mt)
     mt = mt.key_rows_by(**hl.min_rep(mt.locus, mt.alleles))
 


### PR DESCRIPTION
We're now on our third different implementation of the expression for original alt alleles.

The Hail 0.1 version used `contig` and `altAlleles`:
https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/1719af96cfb5a06c5b41a2c5244657803c8a22df/hail_scripts/v01/utils/computed_fields.py#L374-L377

Originally, the Hail 0.2 version used `old_locus` and `old_alleles` (fields created by [hl.methods.split_multi](https://hail.is/docs/0.2/methods/genetics.html?highlight=split#hail.methods.split_multi)), assuming `get_expr_for_original_alt_alleles_set` would be run after `split_multi`:
https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/eb809528f25f9c055bf50fcca129873df473d23e/hail_scripts/v02/utils/computed_fields/variant_id.py#L23-L29

#82 changed that to use `locus` and `alleles`, requiring that `get_expr_for_orig_alt_alleles` be run before splitting. Unlike the other two, this version returns missing if the variant is not multi-allelic.
https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/1719af96cfb5a06c5b41a2c5244657803c8a22df/hail_scripts/v02/utils/computed_fields/variant_id.py#L34-L36


Given the amount of churn on this function, it seems that there is not a clear consensus on how this field should be defined. Thus, this change removes the original alt alleles function in favor of a more general and explicit method: `get_expr_for_variant_ids` (introduced in #82).

`get_expr_for_variant_ids` is also modified to accept a locus and alleles as arguments instead of a Table/MatrixTable, as proposed in https://github.com/macarthur-lab/hail-elasticsearch-pipelines/pull/82#discussion_r235033546. This allows it to be used before splitting with `locus` and `alleles` or after splitting with `old_locus` and `old_alleles`.