### PR TITLE
Add helpers for transcript consequence level flags

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/flags.py
+++ b/hail_scripts/v02/utils/computed_fields/flags.py
@@ -1,11 +1,16 @@
 import hail as hl
 
 
-def get_expr_for_lc_lof_flag(sortedTranscriptConsequences):
-    """Flag a variant if no LoF annotations are marked HC"""
+def get_expr_for_consequence_lc_lof_flag(transcript_consequence):
+    """Flag a transcript consequence if it has an LOFTEE annotation other than HC"""
+    return hl.or_else((transcript_consequence.lof != "") & (transcript_consequence.lof != "HC"), False)
+
+
+def get_expr_for_variant_lc_lof_flag(sorted_transcript_consequences):
+    """Flag a variant if it has some transcript consequences with LOFTEE annotations and none are marked HC"""
     return hl.bind(
         lambda lof_annotations: (lof_annotations.size() > 0) & lof_annotations.all(lambda csq: csq.lof != "HC"),
-        sortedTranscriptConsequences.filter(lambda csq: csq.lof != ""),
+        sorted_transcript_consequences.filter(lambda csq: csq.lof != ""),
     )
 
 
@@ -26,11 +31,16 @@ def get_expr_for_genes_with_lc_lof_flag(sorted_transcript_consequences):
     )
 
 
-def get_expr_for_loftee_flag_flag(sortedTranscriptConsequences):
-    """Flag a variant if all annotations have LOFTEE flags"""
+def get_expr_for_consequence_loftee_flag_flag(transcript_consequence):
+    """Flag a transcript consequence if it has a LOFTEE annotation with flags"""
+    return hl.or_else((transcript_consequence.lof != "") & (transcript_consequence.lof_flags != ""), False)
+
+
+def get_expr_for_variant_loftee_flag_flag(sorted_transcript_consequences):
+    """Flag a variant if it has some transcript consequences with LOFTEE annotations and all have flags"""
     return hl.bind(
         lambda lof_annotations: (lof_annotations.size() > 0) & lof_annotations.all(lambda csq: csq.lof_flags != ""),
-        sortedTranscriptConsequences.filter(lambda csq: csq.lof != ""),
+        sorted_transcript_consequences.filter(lambda csq: csq.lof != ""),
     )
 
 

--- a/hail_scripts/v02/utils/computed_fields/test_flags.py
+++ b/hail_scripts/v02/utils/computed_fields/test_flags.py
@@ -3,9 +3,11 @@ import unittest
 import hail as hl
 
 from .flags import (
-    get_expr_for_lc_lof_flag,
+    get_expr_for_consequence_lc_lof_flag,
+    get_expr_for_variant_lc_lof_flag,
     get_expr_for_genes_with_lc_lof_flag,
-    get_expr_for_loftee_flag_flag,
+    get_expr_for_consequence_loftee_flag_flag,
+    get_expr_for_variant_loftee_flag_flag,
     get_expr_for_genes_with_loftee_flag_flag,
 )
 
@@ -53,17 +55,27 @@ class TestFlags(unittest.TestCase):
             ]
         )
 
-    def test_lc_lof_flag(self):
-        self.assertTrue(hl.eval(get_expr_for_lc_lof_flag(self.all_lc_lof)))
-        self.assertFalse(hl.eval(get_expr_for_lc_lof_flag(self.some_lc_lof)))
+    def test_consequence_lc_lof_flag(self):
+        self.assertTrue(hl.eval(get_expr_for_consequence_lc_lof_flag(hl.struct(lof="LC"))))
+        self.assertFalse(hl.eval(get_expr_for_consequence_lc_lof_flag(hl.struct(lof="HC"))))
+        self.assertFalse(hl.eval(get_expr_for_consequence_lc_lof_flag(hl.struct(lof=""))))
+
+    def test_variant_lc_lof_flag(self):
+        self.assertTrue(hl.eval(get_expr_for_variant_lc_lof_flag(self.all_lc_lof)))
+        self.assertFalse(hl.eval(get_expr_for_variant_lc_lof_flag(self.some_lc_lof)))
 
     def test_genes_with_lc_lof_flag(self):
         self.assertSetEqual(hl.eval(get_expr_for_genes_with_lc_lof_flag(self.all_lc_lof)), set(["foo", "bar", "baz"]))
         self.assertSetEqual(hl.eval(get_expr_for_genes_with_lc_lof_flag(self.some_lc_lof)), set(["foo", "bar"]))
 
-    def test_loftee_flag_flag(self):
-        self.assertTrue(hl.eval(get_expr_for_loftee_flag_flag(self.all_loftee_flags)))
-        self.assertFalse(hl.eval(get_expr_for_loftee_flag_flag(self.some_loftee_flags)))
+    def test_consequence_loftee_flag_flag(self):
+        self.assertTrue(hl.eval(get_expr_for_consequence_loftee_flag_flag(hl.struct(lof="HC", lof_flags="foo"))))
+        self.assertFalse(hl.eval(get_expr_for_consequence_loftee_flag_flag(hl.struct(lof="", lof_flags=""))))
+        self.assertFalse(hl.eval(get_expr_for_consequence_loftee_flag_flag(hl.struct(lof="", lof_flags="bar"))))
+
+    def test_variant_loftee_flag_flag(self):
+        self.assertTrue(hl.eval(get_expr_for_variant_loftee_flag_flag(self.all_loftee_flags)))
+        self.assertFalse(hl.eval(get_expr_for_variant_loftee_flag_flag(self.some_loftee_flags)))
 
     def test_genes_with_loftee_flag_flag(self):
         self.assertSetEqual(


### PR DESCRIPTION
Related to macarthur-lab/gnomadjs#369.

Currently, the gnomAD browser flags variants with "LC LoF" and "LOF Flag" based on **all** the variant's transcript consequences. This is appropriate for the region page, but flags on the gene and transcript pages need to be based only on transcript consequences in the selected gene or transcript.

This adds functions to compute flags for the transcript page, based on a single transcript consequence.