### PR TITLE
reference data write dbsnfp v02

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
@@ -1,0 +1,124 @@
+import hail as hl
+from hail.expr import tint, tfloat, tstr
+
+DBNSFP_INFO = {
+    "2.9.3": {
+        "source_path": "gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.chr13.gz",
+        "output_path": "gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.vds"
+    },
+    "3.5": {
+        "source_path": "gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.chr*.gz",
+        "output_path": "gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.vds",
+    },
+}
+
+# Fields from the dataset file.
+DBNSFP_SCHEMA = {
+    '2.9.3': {
+         '#chr': tstr,
+         'pos(1-coor)': tint,
+         'ref': tstr,
+         'alt': tstr,
+         'SIFT_pred': tstr,
+         'Polyphen2_HDIV_pred': tstr,
+         'Polyphen2_HVAR_pred': tstr,
+         'LRT_pred': tstr,
+         'MutationTaster_pred': tstr,
+         'MutationAssessor_pred': tstr,
+         'FATHMM_pred': tstr,
+         'MetaSVM_pred': tstr,
+         'MetaLR_pred': tstr,
+         'VEST3_score': tstr,
+         'VEST3_rankscore': tstr,
+         'PROVEAN_pred': tstr,
+         'M-CAP_pred': tstr,
+         'REVEL_score': tstr,
+         'REVEL_rankscore': tstr,
+         'MutPred_Top5features': tstr,
+         'Eigen-phred': tstr,
+         'Eigen-PC-phred': tstr,
+         'GERP++_RS': tstr,
+         'GERP++_RS_rankscore': tstr,
+         'phyloP46way_primate': tstr,
+         'phyloP46way_primate_rankscore': tstr,
+         'phyloP46way_placental': tstr,
+         'phyloP46way_placental_rankscore': tstr,
+         'phyloP100way_vertebrate': tstr,
+         'phyloP100way_vertebrate_rankscore': tstr,
+         'phastCons46way_primate': tstr,
+         'phastCons46way_primate_rankscore': tstr,
+         'phastCons46way_placental': tstr,
+         'phastCons46way_placental_rankscore': tstr,
+         'phastCons100way_vertebrate': tstr,
+         'phastCons100way_vertebrate_rankscore': tstr,
+         'SiPhy_29way_pi': tstr,
+         'SiPhy_29way_logOdds_rankscore': tstr,
+         'ESP6500_AA_AF': tfloat,
+         # This space is intentional and in the file.
+         'ESP6500_EA_AF ': tfloat,
+         'ARIC5606_AA_AC': tint,
+         'ARIC5606_AA_AF': tfloat,
+         'ARIC5606_EA_AC': tint,
+         'ARIC5606_EA_AF': tfloat,
+    }
+}
+
+def generate_replacement_fields(ht, schema):
+    '''
+    Hail Tables need to have a fields remapping. This function generates a dict from
+    the new transformed field name (whitespace stripped, dash to underscore) to original
+    field name. The original field name references the exact attribute of ht, per
+    hail construct so we can feed it to the select query.
+
+    :param ht: Hail table to reference the original field attribute.
+    :param schema: schema mapping from original field name to type
+    :return: dict of new transformed name to old attr from ht
+    '''
+    def transform(field_name):
+        return field_name.strip(" `#").replace("(1-coor)", "")\
+            .replace("(1-based)", "").replace("-", "_").replace("+", "")
+    return {
+        transform(field_name): getattr(ht, field_name) for field_name in schema.keys()
+    }
+
+def dbnsfp_to_ht(source_path, output_path, dbnsfp_version="2.9.3"):
+    '''
+    Runs the conversion from importing the table from the source path, proessing the
+    fields, and outputing as a matrix table to the output path.
+
+    :param source_path: location of the dbnsfp data
+    :param output_path: location to put the matrix table
+    :param dbnsfp_version: version
+    :return:
+    '''
+    # Import the table using the schema to define the types.
+    ht = hl.import_table(source_path,
+                         types=DBNSFP_SCHEMA[dbnsfp_version],
+                         missing='.',
+                         min_partitions=10000)
+    # get a attribute map to run a select and remap fields.
+    replacement_fields = generate_replacement_fields(ht, DBNSFP_SCHEMA[dbnsfp_version])
+    ht = ht.select(**replacement_fields)
+    ht = ht.filter(ht.alt == ht.ref, keep=False)
+    # Needed for matrix table conversion to denote variant data.
+    ht = ht.key_by(locus=hl.locus(ht.chr, ht.pos), alleles=[ht.ref, ht.alt])
+
+    # create sites-only Matrix Table
+    mt = hl.MatrixTable.from_rows_table(ht)
+
+    mt = mt.annotate_globals(
+        sourceFilePath=source_path,
+        version=dbnsfp_version,
+    )
+
+    mt.write(output_path)
+    return mt
+
+def run():
+    dbnsfp_version="2.9.3"
+    mt = dbnsfp_to_ht(DBNSFP_INFO[dbnsfp_version]["source_path"],
+                      DBNSFP_INFO[dbnsfp_version]["output_path"],
+                      dbnsfp_version)
+    mt.describe()
+
+run()

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
@@ -113,10 +113,10 @@ def dbnsfp_to_ht(source_path, output_path, dbnsfp_version="2.9.3"):
     return ht
 
 def run():
-    dbnsfp_version="2.9.3"
-    ht = dbnsfp_to_ht(DBNSFP_INFO[dbnsfp_version]["source_path"],
-                      DBNSFP_INFO[dbnsfp_version]["output_path"],
-                      dbnsfp_version)
-    ht.describe()
+    for dbnsfp_version, config in DBNSFP_INFO.items():
+        ht = dbnsfp_to_ht(config["source_path"],
+                          config["output_path"],
+                          dbnsfp_version)
+        ht.describe()
 
 run()

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_dbnsfp_ht.py
@@ -4,11 +4,11 @@ from hail.expr import tint, tfloat, tstr
 DBNSFP_INFO = {
     "2.9.3": {
         "source_path": "gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.chr13.gz",
-        "output_path": "gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.vds"
+        "output_path": "gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.ht"
     },
     "3.5": {
         "source_path": "gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.chr*.gz",
-        "output_path": "gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.vds",
+        "output_path": "gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.ht",
     },
 }
 
@@ -103,22 +103,20 @@ def dbnsfp_to_ht(source_path, output_path, dbnsfp_version="2.9.3"):
     # Needed for matrix table conversion to denote variant data.
     ht = ht.key_by(locus=hl.locus(ht.chr, ht.pos), alleles=[ht.ref, ht.alt])
 
-    # create sites-only Matrix Table
-    mt = hl.MatrixTable.from_rows_table(ht)
 
-    mt = mt.annotate_globals(
+    ht = ht.annotate_globals(
         sourceFilePath=source_path,
         version=dbnsfp_version,
     )
 
-    mt.write(output_path)
-    return mt
+    ht.write(output_path)
+    return ht
 
 def run():
     dbnsfp_version="2.9.3"
-    mt = dbnsfp_to_ht(DBNSFP_INFO[dbnsfp_version]["source_path"],
+    ht = dbnsfp_to_ht(DBNSFP_INFO[dbnsfp_version]["source_path"],
                       DBNSFP_INFO[dbnsfp_version]["output_path"],
                       dbnsfp_version)
-    mt.describe()
+    ht.describe()
 
 run()


### PR DESCRIPTION
A port of https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/download_and_create_reference_datasets/v01/hail_scripts/write_dbnsfp_vds.py to V02 (refer for logic comparison). Since this is a small enough file and is only run once, I did a rewrite so some manual validation has to be done. 

# Changes
1. Only focused on 2.9.3 because I could not find the directory location for 3.5, so assumed it wasn't used.
2. Fields logic:
- The old code has a data structure that contains all of the fields of the file, with a `---` for the fields that are not needed. It extracts the ignored fields, drops it, and then remaps the names (e.g. `#chr` => `chr`) .
- I decided we don't need to keep track of the ignored fields? Instead, we just keep track of the needed fields with the types, and do a single select from the transformed field name to the original attribute (e.g. a select on `chr: ht.#chr`). This, if I'm right, does a rename and drop equivalent. Also, less error prone because we whitelist instead of blacklist.
3. key_by change. 
- V01 has a variant object as a key. This is no longer available in v02, and instead we have to key on locus and allele fields https://discuss.hail.is/t/creating-a-variant-representation-on-a-v0-2-table/856/3.

# Testing
I didn't have a cluster so ran this locally, on just one chromosome file. I got this error: 
```
Hail version: 0.2.8-70304a52d33d
Error summary: AssertionError: assertion failed: type mismatch:
  name: global
  actual: Struct{__cols:Array[Struct{}]}
  expect: Struct{__uid_2:Array[Struct{}]}
```
And I imagine it's the same problem as https://github.com/hail-is/hail/issues/5212, since it has a similar error message and the same build, which should be fixed. Also the annotate_globals is super simple, and the object inspection looks fine. After removing that file, I get an out of memory error when trying to write locally, so I did other things to test. 

```
> mt.describe()
----------------------------------------
Global fields:
    'sourceFilePath':     str 
    'version':     str 
----------------------------------------
Column fields:
    None
----------------------------------------
Row fields:
    'chr':     str 
    'pos':     int32 
    'ref':     str 
    'alt':     str 
    'SIFT_pred':     str 
    'Polyphen2_HDIV_pred':     str 
    'Polyphen2_HVAR_pred':     str 
    'LRT_pred':     str 
    'MutationTaster_pred':     str 
    'MutationAssessor_pred':     str 
    'FATHMM_pred':     str 
    'MetaSVM_pred':     str 
    'MetaLR_pred':     str 
    'VEST3_score':     str 
    'VEST3_rankscore':     str 
    'PROVEAN_pred':     str 
    'M_CAP_pred':     str 
    'REVEL_score':     str 
    'REVEL_rankscore':     str 
    'MutPred_Top5features':     str 
    'Eigen_phred':     str 
    'Eigen_PC_phred':     str 
    'GERP_RS':     str 
    'GERP_RS_rankscore':     str 
    'phyloP46way_primate':     str 
    'phyloP46way_primate_rankscore':     str 
    'phyloP46way_placental':     str 
    'phyloP46way_placental_rankscore':     str 
    'phyloP100way_vertebrate':     str 
    'phyloP100way_vertebrate_rankscore':     str 
    'phastCons46way_primate':     str 
    'phastCons46way_primate_rankscore':     str 
    'phastCons46way_placental':     str 
    'phastCons46way_placental_rankscore':     str 
    'phastCons100way_vertebrate':     str 
    'phastCons100way_vertebrate_rankscore':     str 
    'SiPhy_29way_pi':     str 
    'SiPhy_29way_logOdds_rankscore':     str 
    'ESP6500_AA_AF':     float64 
    'ESP6500_EA_AF':     float64 
    'ARIC5606_AA_AC':     int32 
    'ARIC5606_AA_AF':     float64 
    'ARIC5606_EA_AC':     int32 
    'ARIC5606_EA_AF':     float64 
    'locus':     locus<GRCh37> 
    'alleles':     array<str> 
----------------------------------------
Entry fields:
    None
----------------------------------------
Column key: None
Row key: ['locus', 'alleles']
----------------------------------------
```

```
> mt.rows().show(5)


+------+----------+-----+-----+-----------+---------------------+---------------------+
| chr  |      pos | ref | alt | SIFT_pred | Polyphen2_HDIV_pred | Polyphen2_HVAR_pred |
+------+----------+-----+-----+-----------+---------------------+---------------------+
| str  |    int32 | str | str | str       | str                 | str                 |
+------+----------+-----+-----+-----------+---------------------+---------------------+
| "13" | 19600143 | "C" | "A" | NA        | NA                  | NA                  |
| "13" | 19600143 | "C" | "G" | NA        | NA                  | NA                  |
| "13" | 19600144 | "T" | "A" | NA        | NA                  | NA                  |
| "13" | 19600144 | "T" | "C" | NA        | NA                  | NA                  |
| "13" | 19600144 | "T" | "G" | NA        | NA                  | NA                  |
+------+----------+-----+-----+-----------+---------------------+---------------------+

+----------+---------------------+-----------------------+-------------+--------------+
| LRT_pred | MutationTaster_pred | MutationAssessor_pred | FATHMM_pred | MetaSVM_pred |
+----------+---------------------+-----------------------+-------------+--------------+
| str      | str                 | str                   | str         | str          |
+----------+---------------------+-----------------------+-------------+--------------+
| NA       | NA                  | NA                    | NA          | NA           |
| NA       | NA                  | NA                    | NA          | NA           |
| NA       | NA                  | NA                    | NA          | NA           |
| NA       | NA                  | NA                    | NA          | NA           |
| NA       | NA                  | NA                    | NA          | NA           |
+----------+---------------------+-----------------------+-------------+--------------+

+-------------+-------------+-----------------+--------------+------------+-------------+
| MetaLR_pred | VEST3_score | VEST3_rankscore | PROVEAN_pred | M_CAP_pred | REVEL_score |
+-------------+-------------+-----------------+--------------+------------+-------------+
| str         | str         | str             | str          | str        | str         |
+-------------+-------------+-----------------+--------------+------------+-------------+
| NA          | NA          | NA              | NA           | NA         | NA          |
| NA          | NA          | NA              | NA           | NA         | NA          |
| NA          | NA          | NA              | NA           | NA         | NA          |
| NA          | NA          | NA              | NA           | NA         | NA          |
| NA          | NA          | NA              | NA           | NA         | NA          |
+-------------+-------------+-----------------+--------------+------------+-------------+

+-----------------+----------------------+-------------+----------------+---------+
| REVEL_rankscore | MutPred_Top5features | Eigen_phred | Eigen_PC_phred | GERP_RS |
+-----------------+----------------------+-------------+----------------+---------+
| str             | str                  | str         | str            | str     |
+-----------------+----------------------+-------------+----------------+---------+
| NA              | NA                   | "1.009519"  | "0.7779312"    | NA      |
| NA              | NA                   | "1.009519"  | "0.7779312"    | NA      |
| NA              | NA                   | "0.813185"  | "0.5951864"    | NA      |
| NA              | NA                   | "0.813185"  | "0.5951864"    | NA      |
| NA              | NA                   | "0.813185"  | "0.5951864"    | NA      |
+-----------------+----------------------+-------------+----------------+---------+

+-------------------+---------------------+-------------------------------+
| GERP_RS_rankscore | phyloP46way_primate | phyloP46way_primate_rankscore |
+-------------------+---------------------+-------------------------------+
| str               | str                 | str                           |
+-------------------+---------------------+-------------------------------+
| NA                | "0.121000"          | "0.15741"                     |
| NA                | "0.121000"          | "0.15741"                     |
| NA                | "0.102000"          | "0.15555"                     |
| NA                | "0.102000"          | "0.15555"                     |
| NA                | "0.102000"          | "0.15555"                     |
+-------------------+---------------------+-------------------------------+

+-----------------------+---------------------------------+-------------------------+
| phyloP46way_placental | phyloP46way_placental_rankscore | phyloP100way_vertebrate |
+-----------------------+---------------------------------+-------------------------+
| str                   | str                             | str                     |
+-----------------------+---------------------------------+-------------------------+
| "0.119000"            | "0.18210"                       | "1.256000"              |
| "0.119000"            | "0.18210"                       | "1.256000"              |
| "0.103000"            | "0.17682"                       | "0.259000"              |
| "0.103000"            | "0.17682"                       | "0.259000"              |
| "0.103000"            | "0.17682"                       | "0.259000"              |
+-----------------------+---------------------------------+-------------------------+

+-----------------------------------+------------------------+
| phyloP100way_vertebrate_rankscore | phastCons46way_primate |
+-----------------------------------+------------------------+
| str                               | str                    |
+-----------------------------------+------------------------+
| "0.32921"                         | "0.091000"             |
| "0.32921"                         | "0.091000"             |
| "0.18405"                         | "0.096000"             |
| "0.18405"                         | "0.096000"             |
| "0.18405"                         | "0.096000"             |
+-----------------------------------+------------------------+

+----------------------------------+--------------------------+
| phastCons46way_primate_rankscore | phastCons46way_placental |
+----------------------------------+--------------------------+
| str                              | str                      |
+----------------------------------+--------------------------+
| "0.18340"                        | "0.091000"               |
| "0.18340"                        | "0.091000"               |
| "0.18686"                        | "0.096000"               |
| "0.18686"                        | "0.096000"               |
| "0.18686"                        | "0.096000"               |
+----------------------------------+--------------------------+

+------------------------------------+----------------------------+
| phastCons46way_placental_rankscore | phastCons100way_vertebrate |
+------------------------------------+----------------------------+
| str                                | str                        |
+------------------------------------+----------------------------+
| "0.20842"                          | "0.896000"                 |
| "0.20842"                          | "0.896000"                 |
| "0.21009"                          | "0.458000"                 |
| "0.21009"                          | "0.458000"                 |
| "0.21009"                          | "0.458000"                 |
+------------------------------------+----------------------------+

+--------------------------------------+-------------------------+
| phastCons100way_vertebrate_rankscore | SiPhy_29way_pi          |
+--------------------------------------+-------------------------+
| str                                  | str                     |
+--------------------------------------+-------------------------+
| "0.30565"                            | "0.0:0.9992:0.0:8.0E-4" |
| "0.30565"                            | "0.0:0.9992:0.0:8.0E-4" |
| "0.25760"                            | "0.0:6.0E-4:0.0:0.9994" |
| "0.25760"                            | "0.0:6.0E-4:0.0:0.9994" |
| "0.25760"                            | "0.0:6.0E-4:0.0:0.9994" |
+--------------------------------------+-------------------------+

+-------------------------------+---------------+---------------+----------------+
| SiPhy_29way_logOdds_rankscore | ESP6500_AA_AF | ESP6500_EA_AF | ARIC5606_AA_AC |
+-------------------------------+---------------+---------------+----------------+
| str                           |       float64 |       float64 |          int32 |
+-------------------------------+---------------+---------------+----------------+
| "0.18992"                     |            NA |            NA |             NA |
| "0.18992"                     |            NA |            NA |             NA |
| "0.12098"                     |            NA |            NA |             NA |
| "0.12098"                     |            NA |            NA |             NA |
| "0.12098"                     |            NA |            NA |             NA |
+-------------------------------+---------------+---------------+----------------+

+----------------+----------------+----------------+---------------+------------+
| ARIC5606_AA_AF | ARIC5606_EA_AC | ARIC5606_EA_AF | locus         | alleles    |
+----------------+----------------+----------------+---------------+------------+
|        float64 |          int32 |        float64 | locus<GRCh37> | array<str> |
+----------------+----------------+----------------+---------------+------------+
|             NA |             NA |             NA | 13:19600143   | ["C","A"]  |
|             NA |             NA |             NA | 13:19600143   | ["C","G"]  |
|             NA |             NA |             NA | 13:19600144   | ["T","A"]  |
|             NA |             NA |             NA | 13:19600144   | ["T","C"]  |
|             NA |             NA |             NA | 13:19600144   | ["T","G"]  |
+----------------+----------------+----------------+---------------+------------+
showing top 5 rows
```

A cursory comparison to the raw tsv looks good.

# Next steps
Create a script that calls this per convention, and test on a cluster.