### PR TITLE
splice-ai v02

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_splice_ai_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_splice_ai_ht.py
@@ -1,0 +1,50 @@
+import logging
+import os
+
+import hail as hl
+
+CONFIG = {
+    '37':  (
+            'gs://seqr-reference-data/GRCh37/spliceai/exome_spliceai_scores.vcf.gz',
+            'gs://seqr-reference-data/GRCh37/spliceai/whole_genome_filtered_spliceai_scores.vcf.gz'
+    ),
+    '38': (
+            'gs://seqr-reference-data/GRCh38/spliceai/exome_spliceai_scores.liftover.vcf.gz',
+            'gs://seqr-reference-data/GRCh38/spliceai/whole_genome_filtered_spliceai_scores.liftover.vcf.gz'
+    )
+}
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def vcf_to_mt(splice_ai_snvs_path, splice_ai_indels_path):
+    '''
+    Loads the snv path and indels source path to a matrix table and returns the table.
+
+    :param splice_ai_snvs_path: source location
+    :param splice_ai_indels_path: source location
+    :return: matrix table
+    '''
+    logger.info('==> reading in splice_ai vcfs: %s, %s' % (splice_ai_snvs_path, splice_ai_indels_path))
+    mt = hl.import_vcf([splice_ai_snvs_path, splice_ai_indels_path], force_bgz=True, min_partitions=10000)
+    mt = hl.filter_intervals(mt, [hl.parse_locus_interval('1-MT')])
+    mt = mt.persist()
+
+    # Annotate info.max_DS with the max of DS_AG, DS_AL, DS_DG, DS_DL in info.
+    info=mt.info.annotate(max_DS=hl.max([mt.info.DS_AG, mt.info.DS_AL, mt.info.DS_DG, mt.info.DS_DL]))
+    mt = mt.annotate_rows(info=info)
+
+    return mt
+
+def run():
+    for version, config in CONFIG.items():
+        logger.info('===> Version %s' % version)
+        mt = vcf_to_mt(config[0], config[1])
+
+        # Write mt to the same directory as the snv source.
+        dest = os.path.join(os.path.dirname(CONFIG['37'][0]), "spliceai_scores.mt")
+        logger.info('===> Writing to %s' % dest)
+        mt.write(dest)
+        mt.describe()
+
+run()


### PR DESCRIPTION
Another day, another reference dataset. V01: https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/download_and_create_reference_datasets/v01/hail_scripts/write_splice_ai_vds.py

Pretty standard, added some minor tweaks and style changes here and there but core logic should be similar.

# Testing
- Downloaded the 2.5 GB files for 37, truncated them to 5000 lines, and ran locally.
```
> mt.describe()

----------------------------------------
Global fields:
    None
----------------------------------------
Column fields:
    's':     str 
----------------------------------------
Row fields:
    'locus':     locus<GRCh37> 
    'alleles':     array<str> 
    'rsid':     str 
    'qual':     float64 
    'filters':     set<str> 
    'info':     struct {
        SYMBOL: str, 
        STRAND: str, 
        TYPE: str, 
        DIST: int32, 
        DS_AG: float64, 
        DS_AL: float64, 
        DS_DG: float64, 
        DS_DL: float64, 
        DP_AG: int32, 
        DP_AL: int32, 
        DP_DG: int32, 
        DP_DL: int32, 
        max_DS: float64
    } 
----------------------------------------
Entry fields:
    None
----------------------------------------
Column key: ['s']
Row key: ['locus', 'alleles']
----------------------------------------
```

```
> mt.rows().show(4)

----------------------------------------
+---------------+------------+------+-----------+----------+-------------+-------------+
| locus         | alleles    | rsid |      qual | filters  | info.SYMBOL | info.STRAND |
+---------------+------------+------+-----------+----------+-------------+-------------+
| locus<GRCh37> | array<str> | str  |   float64 | set<str> | str         | str         |
+---------------+------------+------+-----------+----------+-------------+-------------+
| 10:92946      | ["C","A"]  | NA   | -1.00e+01 | NA       | "TUBB8"     | "-"         |
| 10:92946      | ["C","G"]  | NA   | -1.00e+01 | NA       | "TUBB8"     | "-"         |
| 10:92946      | ["C","T"]  | NA   | -1.00e+01 | NA       | "TUBB8"     | "-"         |
| 10:92947      | ["A","C"]  | NA   | -1.00e+01 | NA       | "TUBB8"     | "-"         |
+---------------+------------+------+-----------+----------+-------------+-------------+

+-----------+-----------+------------+------------+------------+------------+------------+
| info.TYPE | info.DIST | info.DS_AG | info.DS_AL | info.DS_DG | info.DS_DL | info.DP_AG |
+-----------+-----------+------------+------------+------------+------------+------------+
| str       |     int32 |    float64 |    float64 |    float64 |    float64 |      int32 |
+-----------+-----------+------------+------------+------------+------------+------------+
| "E"       |       -53 |   4.00e-04 |   0.00e+00 |   1.00e-04 |   0.00e+00 |        -10 |
| "E"       |       -53 |   8.00e-04 |   0.00e+00 |   3.00e-04 |   0.00e+00 |         34 |
| "E"       |       -53 |   0.00e+00 |   0.00e+00 |   0.00e+00 |   0.00e+00 |        -26 |
| "E"       |       -54 |   2.00e-04 |   0.00e+00 |   0.00e+00 |   0.00e+00 |        -49 |
+-----------+-----------+------------+------------+------------+------------+------------+

+------------+------------+------------+-------------+
| info.DP_AL | info.DP_DG | info.DP_DL | info.max_DS |
+------------+------------+------------+-------------+
|      int32 |      int32 |      int32 |     float64 |
+------------+------------+------------+-------------+
|        -48 |         35 |        -21 |    4.00e-04 |
|        -27 |         35 |          1 |    8.00e-04 |
|        -10 |          3 |         35 |    0.00e+00 |
|        -11 |          0 |         34 |    2.00e-04 |
+------------+------------+------------+-------------+
showing top 4 rows

```