### PR TITLE
eigen, 1kg, primate_ai

### DIFF
--- a/download_and_create_reference_datasets/v02/create_ht__1kg.py
+++ b/download_and_create_reference_datasets/v02/create_ht__1kg.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from kubernetes.shell_utils import simple_run as run
+
+for genome_version, vcf_path in [
+    ("37", "gs://seqr-reference-data/GRCh37/1kg/1kg.wgs.phase3.20130502.GRCh37_sites.vds"),
+    ("38", "gs://seqr-reference-data/GRCh38/1kg/1kg.wgs.phase3.20170504.GRCh38_sites.vds"),
+]:
+    run(("python3 gcloud_dataproc/v02/run_script.py "
+        "--cluster create-ht-mpc "
+        "hail_scripts/v02/convert_vcf_to_hail.py "
+        "--output-sites-only-ht "
+        f"--genome-version {genome_version} "
+        f"{vcf_path}"))

--- a/download_and_create_reference_datasets/v02/create_ht__eigen.py
+++ b/download_and_create_reference_datasets/v02/create_ht__eigen.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from kubernetes.shell_utils import simple_run as run
+
+for genome_version, vcf_path in [
+    ("37", "gs://seqr-reference-data/GRCh37/eigen/EIGEN_coding_noncoding.grch37.vds"),
+    ("38", "gs://seqr-reference-data/GRCh38/eigen/EIGEN_coding_noncoding.liftover_grch38.vds"),
+]:
+    run(("python3 gcloud_dataproc/v02/run_script.py "
+        "--cluster create-ht-mpc "
+        "hail_scripts/v02/convert_vcf_to_hail.py "
+        "--output-sites-only-ht "
+        f"--genome-version {genome_version} "
+        f"{vcf_path}"))
+    

--- a/download_and_create_reference_datasets/v02/create_ht__primate_ai.py
+++ b/download_and_create_reference_datasets/v02/create_ht__primate_ai.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from kubernetes.shell_utils import simple_run as run
+
+for genome_version, vcf_path in [
+    ("37", "gs://seqr-reference-data/GRCh37/primate_ai/PrimateAI_scores_v0.2.vds"),
+    ("38", "gs://seqr-reference-data/GRCh38/primate_ai/PrimateAI_scores_v0.2.liftover_grch38.vds"),
+]:
+    run(("python3 gcloud_dataproc/v02/run_script.py "
+        "--cluster create-ht-mpc "
+        "hail_scripts/v02/convert_vcf_to_hail.py "
+        "--output-sites-only-ht "
+        f"--genome-version {genome_version} "
+        f"{vcf_path}"))


### PR DESCRIPTION
Eigen, 1kg, and Primate AI according to @bw2 are simple load VCF and export to table and that's why they don't have a corresponding v01 file. 

What I did was use https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/download_and_create_reference_datasets/v02/create_ht__mpc.py which is a standard load and dump on the mpc data as template, and copied over the corresponding reference dataset.

# Testing
None since it's so simple and easier to test on the live data. Will need to learn how to do this.