### PR TITLE
crash submit.py if `gcloud dataproc jobs submit` exit code != 0

### DIFF
--- a/gcloud_dataproc/submit.py
+++ b/gcloud_dataproc/submit.py
@@ -95,4 +95,7 @@ else:
     """ % locals()
 
 print(command)
-os.system(command)
+return_code = os.system(command)
+
+if return_code != 0:
+    raise ValueError("'gcloud dataproc jobs submit ..' command exited with non-zero return code: {}".format(return_code))

--- a/gcloud_dataproc/submit.py
+++ b/gcloud_dataproc/submit.py
@@ -5,6 +5,7 @@ import getpass
 import multiprocessing
 import os
 import socket
+import subprocess
 
 p = argparse.ArgumentParser()
 p.add_argument("-c", "--cluster", default="no-vep")
@@ -95,7 +96,4 @@ else:
     """ % locals()
 
 print(command)
-return_code = os.system(command)
-
-if return_code != 0:
-    raise ValueError("'gcloud dataproc jobs submit ..' command exited with non-zero return code: {}".format(return_code))
+subprocess.check_call(command, shell=True)


### PR DESCRIPTION
Quick fix for delete-temp-nodes issue:

`gcloud dataproc jobs submit` returns a non-zero exit code if the dataproc pipeline crashes. 
This fix then also crashes  `submit.py` so that wrapper scripts (like `load_dataset.py`) can exit without running cleanup steps like delete-temp-loading-nodes and leaving intermediate data for reruns.