### PR TITLE
Change contig/xpos functions to accept a locus instead of a table

### DIFF
--- a/hail_scripts/v02/load_clinvar_to_es.py
+++ b/hail_scripts/v02/load_clinvar_to_es.py
@@ -68,7 +68,7 @@ review_status_str = hl.delimit(hl.sorted(hl.array(hl.set(mt.info.CLNREVSTAT)), k
 mt = mt.select_rows(
     allele_id=mt.info.ALLELEID,
     alt=get_expr_for_alt_allele(mt),
-    chrom=get_expr_for_contig(mt),
+    chrom=get_expr_for_contig(mt.locus),
     clinical_significance=hl.delimit(hl.sorted(hl.array(hl.set(mt.info.CLNSIG)), key=lambda s: s.replace("^_", "z"))),
     domains=get_expr_for_vep_protein_domains_set(vep_transcript_consequences_root=mt.vep.transcript_consequences),
     gene_ids=mt.gene_ids,
@@ -91,7 +91,7 @@ mt = mt.select_rows(
         vep_transcript_consequences_root=mt.sortedTranscriptConsequences
     ),
     variant_id=get_expr_for_variant_id(mt),
-    xpos=get_expr_for_xpos(mt),
+    xpos=get_expr_for_xpos(mt.locus),
 )
 
 print("\n=== Summary ===")

--- a/hail_scripts/v02/utils/computed_fields/test_variant_id.py
+++ b/hail_scripts/v02/utils/computed_fields/test_variant_id.py
@@ -1,0 +1,23 @@
+import unittest
+
+import hail as hl
+
+from .variant_id import get_expr_for_xpos
+
+
+class TestXpos(unittest.TestCase):
+    def test_xpos_1(self):
+        locus = hl.parse_locus("1:55505463", "GRCh37")
+        self.assertEqual(hl.eval(get_expr_for_xpos(locus)), 1055505463)
+
+    def test_xpos_2(self):
+        locus = hl.parse_locus("X:18525192", "GRCh37")
+        self.assertEqual(hl.eval(get_expr_for_xpos(locus)), 23018525192)
+
+    def test_xpos_grch38(self):
+        locus = hl.parse_locus("chr2:166847734", "GRCh38")
+        self.assertEqual(hl.eval(get_expr_for_xpos(locus)), 2166847734)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hail_scripts/v02/utils/computed_fields/variant_id.py
+++ b/hail_scripts/v02/utils/computed_fields/variant_id.py
@@ -5,18 +5,24 @@ def get_expr_for_alt_allele(table:hl.Table) -> hl.str:
     return table.alleles[1]
 
 
-def get_expr_for_contig(table:hl.Table) -> hl.str:
+def get_expr_for_contig(locus: hl.expr.LocusExpression) -> hl.expr.StringExpression:
     """Normalized contig name"""
-    return hl.str(table.locus.contig)
+    return locus.contig.replace("^chr", "")
 
 
-def get_expr_for_contig_number(table:hl.Table) -> hl.int:
+def get_expr_for_contig_number(
+    locus: hl.expr.LocusExpression
+) -> hl.expr.Int32Expression:
     """Convert contig name to contig number"""
     return hl.bind(
         lambda contig: (
-            hl.case().when(contig == "X", 23).when(contig == "Y", 24).when(contig[0] == "M", 25).default(hl.int(contig))
+            hl.case()
+            .when(contig == "X", 23)
+            .when(contig == "Y", 24)
+            .when(contig[0] == "M", 25)
+            .default(hl.int(contig))
         ),
-        get_expr_for_contig(table),
+        get_expr_for_contig(locus),
     )
 
 
@@ -51,16 +57,16 @@ def get_expr_for_variant_id(table, max_length=None):
     Return:
         string: "<chrom>-<pos>-<ref>-<alt>"
     """
-    contig = get_expr_for_contig(table)
+    contig = get_expr_for_contig(table.locus)
     variant_id = contig + "-" + hl.str(table.locus.position) + "-" + table.alleles[0] + "-" + table.alleles[1]
     if max_length is not None:
         return variant_id[0:max_length]
     return variant_id
 
 
-def get_expr_for_xpos(table: hl.MatrixTable):
+def get_expr_for_xpos(locus: hl.expr.LocusExpression) -> hl.expr.Int64Expression:
     """Genomic position represented as a single number = contig_number * 10**9 + position.
     This represents chrom:pos more compactly and allows for easier sorting.
     """
-    contig_number = get_expr_for_contig_number(table)
-    return hl.int64(contig_number) * 1_000_000_000 + table.locus.position
+    contig_number = get_expr_for_contig_number(locus)
+    return hl.int64(contig_number) * 1_000_000_000 + locus.position


### PR DESCRIPTION
Currently, the functions for contig, contig number, and xpos all accept a Table/MatrixTable and return a value derived from the `locus` field of that table. However, for some datasets (such as a table of regions with start/stop positions) it would be useful to calculate xpos for fields other than `locus`.

This changes the functions for contig, contig number, and xpos to accept a LocusExpression instead of a Table so that they can be used on any field.

It also changes `get_expr_for_contig` to remove the "chr" prefix from contigs so that `get_expr_for_contig_number` and `get_expr_for_xpos` will work with GRCh38 loci.