### PR TITLE
seqr write validation ht

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_dataset_validation_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_dataset_validation_ht.py
@@ -5,6 +5,13 @@ import hail as hl
 from hail_scripts.v02.utils.computed_fields.vep import get_expr_for_vep_sorted_transcript_consequences_array, \
     get_expr_for_worst_transcript_consequence_annotations_struct, CONSEQUENCE_TERM_RANK_LOOKUP
 
+VALIDATION_KEYTABLE_PATHS = {
+    'coding_37': 'gs://seqr-reference-data/GRCh37/validate_ht/common_coding_variants.grch37.ht',
+    'coding_38': 'gs://seqr-reference-data/GRCh38/validate_ht/common_coding_variants.grch38.ht',
+    'noncoding_37': 'gs://seqr-reference-data/GRCh37/validate_ht/common_noncoding_variants.grch37.ht',
+    'noncoding_38': 'gs://seqr-reference-data/GRCh38/validate_ht/common_noncoding_variants.grch38.ht',
+}
+
 logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s')
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -16,10 +23,12 @@ args = p.parse_args()
 
 def read_gnomad_subset(genome_version):
     logger.info("==> Read gnomAD subset")
+    filtered_contig = '1' if genome_version == '37' else 'chr1'
 
     # select a subset of gnomad genomes variants that are in > 90% of samples
-    ht = hl.split_multi(hl.read_table('gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht'))
-    ht = hl.filter_intervals(ht, [hl.parse_locus_interval('1', reference_genome='GRCh%s'%genome_version)])
+    ht = hl.read_table('gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht')
+    ht = hl.filter_intervals(ht, [hl.parse_locus_interval(filtered_contig,
+                                                          reference_genome='GRCh%s'%genome_version)])
     ht = ht.filter(ht.freq[0].AF > 0.90)
 
     ht = ht.annotate(sorted_transaction_consequences=(
@@ -37,7 +46,7 @@ def read_gnomad_subset(genome_version):
 def write_out_ht(ht, output_path):
     ht = ht.select()
     print(ht.count())
-    # ht.write(output_path, overwrite=True)
+    ht.write(output_path, overwrite=True)
 
 
 ht = read_gnomad_subset(args.genome_version)
@@ -45,9 +54,9 @@ ht.persist()
 
 coding_ht = ht.filter(
     hl.int(ht.main_transcript.major_consequence_rank) <= hl.int(CONSEQUENCE_TERM_RANK_LOOKUP.get('synonymous_variant')))
-write_out_ht(coding_ht, 'gs://seqr-kev/combined-test/validation-coding.ht')
+write_out_ht(coding_ht, VALIDATION_KEYTABLE_PATHS['coding_{}'.format(args.genome_version)])
 
 
 noncoding_ht = ht.filter(
     hl.int(ht.main_transcript.major_consequence_rank) >= hl.int(CONSEQUENCE_TERM_RANK_LOOKUP.get('downstream_gene_variant')))
-write_out_ht(noncoding_ht, 'gs://seqr-kev/combined-test/validation-noncoding.ht')
+write_out_ht(noncoding_ht, VALIDATION_KEYTABLE_PATHS['noncoding_{}'.format(args.genome_version)])

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_dataset_validation_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_dataset_validation_ht.py
@@ -1,0 +1,53 @@
+import argparse as ap
+import logging
+
+import hail as hl
+from hail_scripts.v02.utils.computed_fields.vep import get_expr_for_vep_sorted_transcript_consequences_array, \
+    get_expr_for_worst_transcript_consequence_annotations_struct, CONSEQUENCE_TERM_RANK_LOOKUP
+
+logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+p = ap.ArgumentParser()
+p.add_argument("-g", "--genome-version", help="Genome build: 37 or 38", choices=["37", "38"], default="37")
+args = p.parse_args()
+
+
+def read_gnomad_subset(genome_version):
+    logger.info("==> Read gnomAD subset")
+
+    # select a subset of gnomad genomes variants that are in > 90% of samples
+    ht = hl.split_multi(hl.read_table('gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht'))
+    ht = hl.filter_intervals(ht, [hl.parse_locus_interval('1', reference_genome='GRCh%s'%genome_version)])
+    ht = ht.filter(ht.freq[0].AF > 0.90)
+
+    ht = ht.annotate(sorted_transaction_consequences=(
+        get_expr_for_vep_sorted_transcript_consequences_array(ht.vep, omit_consequences=[]))
+    )
+    ht = ht.annotate(main_transcript=(
+        get_expr_for_worst_transcript_consequence_annotations_struct(ht.sorted_transaction_consequences))
+    )
+
+    ht.describe()
+
+    return ht
+
+
+def write_out_ht(ht, output_path):
+    ht = ht.select()
+    print(ht.count())
+    # ht.write(output_path, overwrite=True)
+
+
+ht = read_gnomad_subset(args.genome_version)
+ht.persist()
+
+coding_ht = ht.filter(
+    hl.int(ht.main_transcript.major_consequence_rank) <= hl.int(CONSEQUENCE_TERM_RANK_LOOKUP.get('synonymous_variant')))
+write_out_ht(coding_ht, 'gs://seqr-kev/combined-test/validation-coding.ht')
+
+
+noncoding_ht = ht.filter(
+    hl.int(ht.main_transcript.major_consequence_rank) >= hl.int(CONSEQUENCE_TERM_RANK_LOOKUP.get('downstream_gene_variant')))
+write_out_ht(noncoding_ht, 'gs://seqr-kev/combined-test/validation-noncoding.ht')

--- a/hail_scripts/v02/utils/computed_fields/vep.py
+++ b/hail_scripts/v02/utils/computed_fields/vep.py
@@ -183,7 +183,7 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root,
             ]
         )
 
-    omit_consequence_terms = hl.set(omit_consequences) if len(omit_consequences) > 0 else hl.empty_set(hl.tstr)
+    omit_consequence_terms = hl.set(omit_consequences) if omit_consequences else hl.empty_set(hl.tstr)
 
     result = hl.sorted(
         vep_root.transcript_consequences.map(

--- a/hail_scripts/v02/utils/computed_fields/vep.py
+++ b/hail_scripts/v02/utils/computed_fields/vep.py
@@ -49,6 +49,11 @@ CONSEQUENCE_TERMS = [
 CONSEQUENCE_TERM_RANK_LOOKUP = hl.dict({term: rank for rank, term in enumerate(CONSEQUENCE_TERMS)})
 
 
+OMIT_CONSEQUENCE_TERMS = [
+    "upstream_gene_variant",
+    "downstream_gene_variant",
+]
+
 def get_expr_for_vep_consequence_terms_set(vep_transcript_consequences_root):
     return hl.set(vep_transcript_consequences_root.flatmap(lambda c: c.consequence_terms))
 
@@ -124,7 +129,9 @@ def get_expr_for_formatted_hgvs(csq):
     )
 
 
-def get_expr_for_vep_sorted_transcript_consequences_array(vep_root, include_coding_annotations=True):
+def get_expr_for_vep_sorted_transcript_consequences_array(vep_root,
+                                                          include_coding_annotations=True,
+                                                          omit_consequences=OMIT_CONSEQUENCE_TERMS):
     """Sort transcripts by 3 properties:
 
         1. coding > non-coding
@@ -176,7 +183,7 @@ def get_expr_for_vep_sorted_transcript_consequences_array(vep_root, include_codi
             ]
         )
 
-    omit_consequence_terms = hl.set(["upstream_gene_variant", "downstream_gene_variant"])
+    omit_consequence_terms = hl.set(omit_consequences) if len(omit_consequences) > 0 else hl.empty_set(hl.tstr)
 
     result = hl.sorted(
         vep_root.transcript_consequences.map(


### PR DESCRIPTION
Another day, another data set. This is the validation data set used in seqr to validate the incoming variants https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/hail_scripts/v01/utils/validate_vds.py#L43.

It wasn't a lot of code and isn't run often, so I decided to do an almost 1 to 1 port of https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/download_and_create_reference_datasets/v01/hail_scripts/write_dataset_validation_kt.py.

# Testing:
## For non-coding file:
v01: 
```
> hc.read_table('gs://seqr-reference-data/GRCh37/validate_vds/common_noncoding_variants.grch37.kt').count()
- 1880L

```

v02:
```
> hl.read_table('gs://seqr-kev/combined-test/validation-noncoding.ht').count()
- 2243
```

## For coding variants:
v01: 
```
> hc.read_table('gs://seqr-reference-data/GRCh37/validate_vds/common_coding_variants.grch37.kt').count()
- 354L
```

v02:
```
> hl.read_table('gs://seqr-kev/combined-test/validation-noncoding.ht').count()
- 359

```

On cursory glance, there seems to be overlap between the 2. 

