### PR TITLE
Kev/v02 ref data combine

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_1kg_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_1kg_ht.py
@@ -46,14 +46,22 @@ def vcf_to_mt(path, genome_version):
 
     return all_mt
 
+def annotate_mt(mt):
+    # Annotate POPMAX_AF, which is max of respective fields using a_index for multi-allelics.
+    return mt.annotate_rows(POPMAX_AF=hl.max(mt.info.AFR_AF[mt.a_index-1],
+                                             mt.info.AMR_AF[mt.a_index - 1],
+                                             mt.info.EAS_AF[mt.a_index - 1],
+                                             mt.info.EUR_AF[mt.a_index - 1],
+                                             mt.info.SAS_AF[mt.a_index - 1]))
 
 def run():
    for genome_version, path in CONFIG.items():
        logger.info('reading from input path: %s' % path)
+
        mt = vcf_to_mt(path, genome_version)
+       mt = annotate_mt(mt)
 
        mt.describe()
-       mt.rows().show()
 
        output_path = path.replace(".vcf", "").replace(".gz", "").replace(".bgz", "")\
                          .replace(".*", "").replace("*", "") + ".ht"

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -1,272 +1,167 @@
-import argparse
-import hail
-import logging
-from pprint import pprint
-import time
-
-#from hail_scripts.v01.utils.add_1kg_phase3 import add_1kg_phase3_to_vds, read_1kg_phase3_vds
-#from hail_scripts.v01.utils.add_cadd import add_cadd_to_vds, read_cadd_vds
-#from hail_scripts.v01.utils.add_dbnsfp import add_dbnsfp_to_vds, read_dbnsfp_vds
-#from hail_scripts.v01.utils.add_eigen import add_eigen_to_vds, read_eigen_vds
-#from hail_scripts.v01.utils.add_exac import add_exac_to_vds, read_exac_vds
-#from hail_scripts.v01.utils.add_gnomad import add_gnomad_to_vds, read_gnomad_vds
-#from hail_scripts.v01.utils.add_gnomad_coverage import add_gnomad_exome_coverage_to_vds, add_gnomad_genome_coverage_to_vds
-#from hail_scripts.v01.utils.add_mpc import add_mpc_to_vds, read_mpc_vds
-#from hail_scripts.v01.utils.add_primate_ai import add_primate_ai_to_vds, read_primate_ai_vds
-#from hail_scripts.v01.utils.add_topmed import add_topmed_to_vds, read_topmed_vds
-#from hail_scripts.v01.utils.gcloud_utils import delete_gcloud_file
-#from hail_scripts.v01.utils.hail_utils import create_hail_context
-#from hail_scripts.v01.utils.vds_utils import write_vds, read_vds
-
-logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s')
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-
-p = argparse.ArgumentParser()
-p.add_argument("-g", "--genome-version", help="Genome build: 37 or 38", choices=["37", "38"], required=True)
-
-p.add_argument("--output-vds", help="Output vds path",
-               default="gs://seqr-reference-data/GRCh{genome_version}/all_reference_data/combined_reference_data_grch{genome_version}.ht")
-
-p.add_argument("--exclude-topmed", action="store_true", help="Don't add TopMed AFs. Intended for testing.")
-p.add_argument("--exclude-mpc", action="store_true", help="Don't add MPC fields. Intended for testing.")
-
-p.add_argument("--exclude-dbnsfp", action="store_true", help="Don't add annotations from dbnsfp. Intended for testing.")
-p.add_argument("--exclude-1kg", action="store_true", help="Don't add 1kg AFs. Intended for testing.")
-p.add_argument("--exclude-gene-constraint", action="store_true", help="Don't add gene constraint columns. Intended for testing.")
-p.add_argument("--exclude-eigen", action="store_true", help="Don't add Eigen scores. Intended for testing.")
-p.add_argument("--exclude-cadd", action="store_true", help="Don't add CADD scores (they take a really long time to load). Intended for testing.")
-p.add_argument("--exclude-gnomad", action="store_true", help="Don't add gnomAD exome or genome fields. Intended for testing.")
-p.add_argument("--exclude-exac", action="store_true", help="Don't add ExAC fields. Intended for testing.")
-p.add_argument("--exclude-primate-ai", action="store_true", help="Don't add PrimateAI fields. Intended for testing.")
-p.add_argument("--exclude-gnomad-coverage", action="store_true", help="Don't add gnomAD exome and genome coverage. Intended for testing.")
-
-p.add_argument("--start-with-step", help="Skip steps that completed previously", type=int, default=0, choices=[0, 1, 2, 3, 4])
-p.add_argument("--dont-delete-intermediate-files", action="store_true",
-               help="Keep intermediate VDS files to allow restarting the pipeline from the middle using --start-with-step")
-
-p.add_argument('--test', help="Test on a small subset of the data.", action="store_true")
-
-
-
-#p.add_argument("-H", "--host", help="Elasticsearch node host or IP. To look this up, run: `kubectl describe nodes | grep Addresses`")
-#p.add_argument("-p", "--port", help="Elasticsearch port", default=30001, type=int)  # 9200
-#p.add_argument("--export-to-vds", help="Path of vds", default="gs://seqr-reference-data/GRCh%(genome_version)s/all_reference_data/all_reference_data.vds")
-#p.add_argument("--export-to-elastic-search", help="Whether to export the data to elasticsearch", action="store_true")
-#p.add_argument("--index", help="Elasticsearch index name", default="all-reference-data")
-#p.add_argument("--index-type", help="Elasticsearch index type", default="variant")
-#p.add_argument("--block-size", help="Elasticsearch block size", default=200, type=int)
-#p.add_argument("--num-shards", help="Number of shards", default=1, type=int)
-
-args = p.parse_args()
-
-filter_interval = args.subset if args.subset else None  #"1-MT"
-
-output_vds = args.output_vds.format(genome_version=args.genome_version)
-
-test_output_vds = output_vds + ".test"
-step0_output_vds = output_vds.replace(".vds", "") + "_minimal.vds"
-step1_output_vds = output_vds.replace(".vds", "") + "_with_coverage1.vds"
-step2_output_vds = output_vds.replace(".vds", "") + "_with_coverage2.vds"
-step3_output_vds = output_vds.replace(".vds", "") + "_annotations1.vds"
-
-
-if args.start_with_step == 0:
-    logger.info("\n=============================== step 0 - combine all datasets into 1 minimal vds ===============================")
-    hc = create_hail_context()
-
-    # check that args.output_vds path is writable
-    with hail.utils.hadoop_write(test_output_vds) as f:
-        f.write("")
-    delete_gcloud_file(test_output_vds)
-
-    # compute a vds that contains the union of all variants from all the reference datasets
-    all_vds_objects = []
-    if not args.exclude_cadd: all_vds_objects.append(read_cadd_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_dbnsfp: all_vds_objects.append(read_dbnsfp_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_1kg: all_vds_objects.append(read_1kg_phase3_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_exac: all_vds_objects.append(read_exac_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_topmed: all_vds_objects.append(read_topmed_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_mpc: all_vds_objects.append(read_mpc_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_gnomad: all_vds_objects.append(read_gnomad_vds(hc, args.genome_version, "exomes", subset=filter_interval))
-    if not args.exclude_gnomad: all_vds_objects.append(read_gnomad_vds(hc, args.genome_version, "genomes", subset=filter_interval))
-    if not args.exclude_eigen: all_vds_objects.append(read_eigen_vds(hc, args.genome_version, subset=filter_interval))
-    if not args.exclude_primate_ai: all_vds_objects.append(read_primate_ai_vds(hc, args.genome_version, subset=filter_interval))
-
-    all_vds_objects_with_minimal_schema = []
-    for vds_object in all_vds_objects:
-        all_vds_objects_with_minimal_schema.append(
-            vds_object.annotate_variants_expr('va = {}'))  # drop all variant-level fields except chrom-pos-ref-alt
-
-    vds = hail.VariantDataset.union(*all_vds_objects_with_minimal_schema)
-    vds = vds.deduplicate()
-
-    write_vds(vds, step0_output_vds)
-
-    hc.stop()
-
-
-if args.start_with_step <= 1:
-    logger.info("=============================== step 1 - read in minimal vds and add in gnomAD exomes coverage ===============================")
-
-    hc = create_hail_context()
-    vds = read_vds(hc, step0_output_vds)
-
-    pprint(vds.variant_schema)
-
-    # start with the cadd vds since it contains all possible SNPs and common indels
-    if not args.exclude_gnomad_coverage:
-        vds = add_gnomad_exome_coverage_to_vds(hc, vds, args.genome_version, root="va.gnomad_exome_coverage")
-
-    write_vds(vds, step1_output_vds)
-
-    hc.stop()
-
-    #if not args.dont_delete_intermediate_vds_files:
-    #    delete_gcloud_file(step0_output_vds, is_directory=True)
-
-if args.start_with_step <= 2:
-    logger.info("=============================== step 2 - read in minimal vds and add in gnomAD genomes coverage ===============================")
-
-    hc = create_hail_context()
-    vds = read_vds(hc, step1_output_vds)
-
-    pprint(vds.variant_schema)
-
-    # start with the cadd vds since it contains all possible SNPs and common indels
-    if not args.exclude_gnomad_coverage:
-        vds = add_gnomad_genome_coverage_to_vds(hc, vds, args.genome_version, root="va.gnomad_genome_coverage")
-
-    write_vds(vds, step2_output_vds)
-
-    hc.stop()
-
-    #if not args.dont_delete_intermediate_vds_files:
-    #    delete_gcloud_file(step1_output_vds, is_directory=True)
-
-if args.start_with_step <= 3:
-
-    logger.info("\n=============================== step 3 - read in vds and annotate it with reference datasets ===============================")
-
-    hc = create_hail_context()
-    vds = read_vds(hc, step2_output_vds)
-
-    pprint(vds.variant_schema)
-
-    if not args.exclude_cadd:
-        logger.info("\n==> add cadd")
-        vds = add_cadd_to_vds(hc, vds, args.genome_version, root="va.cadd", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_eigen:
-        logger.info("\n==> add eigen")
-        vds = add_eigen_to_vds(hc, vds, args.genome_version, root="va.eigen", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_1kg:
-        logger.info("\n==> add 1kg")
-        vds = add_1kg_phase3_to_vds(hc, vds, args.genome_version, root="va.g1k", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_exac:
-        logger.info("\n==> add exac")
-        vds = add_exac_to_vds(hc, vds, args.genome_version, root="va.exac", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_mpc:
-        logger.info("\n==> add mpc")
-        vds = add_mpc_to_vds(hc, vds, args.genome_version, root="va.mpc", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    write_vds(vds, step3_output_vds)
-
-    hc.stop()
-
-if args.start_with_step <= 4:
-
-    logger.info("\n=============================== step 4 - read in vds and annotate it with additional reference datasets ===============================")
-
-    hc = create_hail_context()
-    vds = read_vds(hc, step3_output_vds)
-
-    if not args.exclude_gnomad:
-        logger.info("\n==> add gnomad exomes")
-        vds = add_gnomad_to_vds(hc, vds, args.genome_version, exomes_or_genomes="exomes", root="va.gnomad_exomes", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_gnomad:
-        logger.info("\n==> add gnomad genomes")
-        vds = add_gnomad_to_vds(hc, vds, args.genome_version, exomes_or_genomes="genomes", root="va.gnomad_genomes", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_dbnsfp:
-        logger.info("\n==> add dbnsfp")
-        vds = add_dbnsfp_to_vds(hc, vds, args.genome_version, root="va.dbnsfp", subset=filter_interval)
-
-        if args.genome_version == "37":
-            # dbNSFP is missing DANN scores for GRCh37, so add it from hail annotationdb.
-            # Later when annotationdb is available GRCh38 use it for everything.
-            vds = vds.annotate_variants_db('va.dann.score')\
-                .annotate_variants_expr("va.dbnsfp.DANN_score = va.dann.score")\
-                .annotate_variants_expr("va = drop(va, dann)")
-
-        pprint(vds.variant_schema)
-
-    if not args.exclude_topmed:
-        logger.info("\n==> add topmed")
-        vds = add_topmed_to_vds(hc, vds, args.genome_version, root="va.topmed", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    if not args.exclude_primate_ai:
-        logger.info("\n==> add primate_ai")
-        vds = add_primate_ai_to_vds(hc, vds, args.genome_version, root="va.primate_ai", subset=filter_interval)
-        pprint(vds.variant_schema)
-
-    # DON'T add clinvar because it updates frequently
-    #if not args.exclude_clinvar:
-    #    logger.info("\n==> Add clinvar")
-    #    vds = add_clinvar_to_vds(hc, vds, args.genome_version, root="va.clinvar", subset=filter_interval)
-
-    # DON'T add hgmd because it's got a restrictive license, so only staff users can use it
-    #if not args.exclude_hgmd:
-    #    logger.info("\n==> Add hgmd")
-    #    vds = add_hgmd_to_vds(hc, vds, args.genome_version, root="va.hgmd", subset=filter_interval)
-
-    pprint(vds.variant_schema)
-
-    write_vds(vds, output_vds)
-
-    #if not args.dont_delete_intermediate_vds_files:
-    #    delete_gcloud_file(step2_output_vds)
-
-
-summary = vds.summarize()
-pprint(summary)
-
-
-
-
-"""
-from hail_scripts.v01.utils.elasticsearch_client import ElasticsearchClient
-
-DISABLE_INDEX_AND_DOC_VALUES_FOR_FIELDS = ("sortedTranscriptConsequences", )
-
-print("======== Export to elasticsearch ======")
-es = ElasticsearchClient(
-    host=args.host,
-    port=args.port,
-)
-
-es.export_vds_to_elasticsearch(
-    vds,
-    index_name=args.index,
-    index_type_name=args.index_type,
-    block_size=args.block_size,
-    num_shards=args.num_shards,
-    delete_index_before_exporting=True,
-    disable_doc_values_for_fields=DISABLE_INDEX_AND_DOC_VALUES_FOR_FIELDS,
-    disable_index_for_fields=DISABLE_INDEX_AND_DOC_VALUES_FOR_FIELDS,
-    verbose=True,
-)
-"""
+import os
+
+import hail as hl
+
+OUTPUT_DIR = 'gs://seqr-kev/combined-test'
+
+CONFIG =  {
+    '1kg': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/1kg/1kg.wgs.phase3.20130502.GRCh37_sites.ht',
+            'selection': {'AC': 'info.AC', 'AF': 'info.AF', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
+            'field_name': 'g1k',
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/1kg/1kg.wgs.phase3.20170504.GRCh38_sites.ht',
+            'selection': {'AC': 'info.AC', 'AF': 'info.AF', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
+            'field_name': 'g1k',
+        },
+    },
+    'cadd': {
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/CADD/CADD_snvs_and_indels.v1.4.ht',
+            'selection': ['PHRED'],
+        },
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/CADD/CADD_snvs_and_indels.v1.4.ht',
+            'selection': ['PHRED'],
+        },
+    },
+    'dbnsfp': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.ht',
+            'selection': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
+                          'GERP_RS', 'phastCons100way_vertebrate'],
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.ht',
+            'selection': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
+                          'GERP_RS', 'phastCons100way_vertebrate'],
+        },
+    },
+    'eigen': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/eigen/EIGEN_coding_noncoding.grch37.ht',
+            'selection': {'Eigen_phred': 'info.Eigen-phred'},
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/eigen/EIGEN_coding_noncoding.liftover_grch38.ht',
+            'selection': {'Eigen_phred': 'info.Eigen-phred'},
+        },
+    },
+    'mpc': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/MPC/fordist_constraint_official_mpc_values.ht',
+            'selection': {'MPC': 'info.MPC'},
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/MPC/fordist_constraint_official_mpc_values.liftover.GRCh38.ht',
+            'selection': {'MPC': 'info.MPC'},
+        },
+    },
+    'primate_ai': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/primate_ai/PrimateAI_scores_v0.2.ht',
+            'selection': {'score': 'info.score'},
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/primate_ai/PrimateAI_scores_v0.2.liftover_grch38.ht',
+            'selection': {'score': 'info.score'},
+        },
+    },
+    'splice_ai': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/spliceai/spliceai_scores.ht',
+            'selection': {'delta_score': 'info.max_DS'},
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/spliceai/spliceai_scores.ht',
+            'selection': {'delta_score': 'info.max_DS'},
+        },
+    },
+    'topmed': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/TopMed/bravo-dbsnp-all.removed_chr_prefix.liftunder_GRCh37.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+        '38': {
+            'path': 'gs://seqr-reference-data/GRCh38/TopMed/bravo-dbsnp-all.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+    'gnomad_exome_coverage': {
+        '37': {
+            'path': 'gs://gnomad-public/release/2.1/coverage/exomes/gnomad.exomes.r2.1.coverage.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+    'gnomad_genome_coverage': {
+        '37': {
+            'path': 'gs://gnomad-public/release/2.1/coverage/genomes/gnomad.genomes.r2.1.coverage.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+    'gnomad_exomes': {
+        '37': {
+            'path': 'gs://gnomad-public/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+    'gnomad_genome': {
+        '37': {
+            'path': 'gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+    'exac': {
+        '37': {
+            'path': 'gs://seqr-reference-data/GRCh37/TopMed/bravo-dbsnp-all.removed_chr_prefix.liftunder_GRCh37.ht',
+            'selection': {'AC': 'info.AC'},
+        },
+    },
+
+}
+
+def get_mt(dataset, reference_genome):
+    config = CONFIG[dataset][reference_genome]
+
+    base_ht = hl.read_table(config['path'])
+
+    field_name = config.get('field_name') or dataset
+    if isinstance(config['selection'], list):
+        select_fields = {selection: base_ht[selection] for selection in config['selection'] }
+    elif isinstance(config['selection'], dict):
+        select_fields = {}
+        for key, val in config['selection'].items():
+            ht = base_ht
+            for attr in val.split('.'):
+                ht = ht[attr]
+            select_fields[key] = ht
+
+    print(select_fields)
+    select_query = {
+        field_name: hl.struct(**select_fields)
+    }
+
+    return base_ht.select(**select_query)
+
+def join_mts(datasets, reference_genome):
+    joined_mt = None
+    for dataset in datasets:
+        dataset_mt = get_mt(dataset, reference_genome)
+        if joined_mt == None:
+            joined_mt = dataset_mt
+            continue
+        else:
+            joined_mt = joined_mt.join(dataset_mt)
+    joined_mt.describe()
+    print(os.path.join(OUTPUT_DIR, 'combined-%s.ht' % '-'.join(datasets)))
+    # joined_mt.write(os.path.join(OUTPUT_DIR, 'combined%s.ht' % combined_str))
+
+def run():
+    join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai'],
+             '37')
+    join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai'],
+             '38')
+
+run()

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -4,123 +4,138 @@ import hail as hl
 
 OUTPUT_DIR = 'gs://seqr-kev/combined-test'
 
+
 CONFIG =  {
     '1kg': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/1kg/1kg.wgs.phase3.20130502.GRCh37_sites.ht',
-            'selection': {'AC': 'info.AC', 'AF': 'info.AF', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
+            'select': {'AC': 'info.AC#', 'AF': 'info.AF#', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
             'field_name': 'g1k',
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/1kg/1kg.wgs.phase3.20170504.GRCh38_sites.ht',
-            'selection': {'AC': 'info.AC', 'AF': 'info.AF', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
+            'select': {'AC': 'info.AC#', 'AF': 'info.AF#', 'AN': 'info.AN', 'POPMAX_AF': 'POPMAX_AF'},
             'field_name': 'g1k',
         },
     },
     'cadd': {
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/CADD/CADD_snvs_and_indels.v1.4.ht',
-            'selection': ['PHRED'],
+            'select': ['PHRED'],
         },
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/CADD/CADD_snvs_and_indels.v1.4.ht',
-            'selection': ['PHRED'],
+            'select': ['PHRED'],
         },
     },
     'dbnsfp': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/dbNSFP/v2.9.3/dbNSFP2.9.3_variant.ht',
-            'selection': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
+            'select': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
                           'GERP_RS', 'phastCons100way_vertebrate'],
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/dbNSFP/v3.5/dbNSFP3.5a_variant.ht',
-            'selection': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
+            'select': ['SIFT_pred', 'Polyphen2_HVAR_pred', 'MutationTaster_pred', 'FATHMM_pred', 'MetaSVM_pred', 'REVEL_score',
                           'GERP_RS', 'phastCons100way_vertebrate'],
         },
     },
     'eigen': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/eigen/EIGEN_coding_noncoding.grch37.ht',
-            'selection': {'Eigen_phred': 'info.Eigen-phred'},
+            'select': {'Eigen_phred': 'info.Eigen-phred'},
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/eigen/EIGEN_coding_noncoding.liftover_grch38.ht',
-            'selection': {'Eigen_phred': 'info.Eigen-phred'},
+            'select': {'Eigen_phred': 'info.Eigen-phred'},
         },
     },
     'mpc': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/MPC/fordist_constraint_official_mpc_values.ht',
-            'selection': {'MPC': 'info.MPC'},
+            'select': {'MPC': 'info.MPC'},
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/MPC/fordist_constraint_official_mpc_values.liftover.GRCh38.ht',
-            'selection': {'MPC': 'info.MPC'},
+            'select': {'MPC': 'info.MPC'},
         },
     },
     'primate_ai': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/primate_ai/PrimateAI_scores_v0.2.ht',
-            'selection': {'score': 'info.score'},
+            'select': {'score': 'info.score'},
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/primate_ai/PrimateAI_scores_v0.2.liftover_grch38.ht',
-            'selection': {'score': 'info.score'},
+            'select': {'score': 'info.score'},
         },
     },
     'splice_ai': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/spliceai/spliceai_scores.ht',
-            'selection': {'delta_score': 'info.max_DS'},
+            'select': {'delta_score': 'info.max_DS'},
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/spliceai/spliceai_scores.ht',
-            'selection': {'delta_score': 'info.max_DS'},
+            'select': {'delta_score': 'info.max_DS'},
         },
     },
     'topmed': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/TopMed/bravo-dbsnp-all.removed_chr_prefix.liftunder_GRCh37.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {'AC': 'info.AC#'},
         },
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/TopMed/bravo-dbsnp-all.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {'AC': 'info.AC#'},
         },
     },
     'gnomad_exome_coverage': {
         '37': {
             'path': 'gs://gnomad-public/release/2.1/coverage/exomes/gnomad.exomes.r2.1.coverage.ht',
-            'selection': {'AC': 'info.AC'},
         },
     },
     'gnomad_genome_coverage': {
         '37': {
             'path': 'gs://gnomad-public/release/2.1/coverage/genomes/gnomad.genomes.r2.1.coverage.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {'AC': 'info.AC'},
         },
     },
     'gnomad_exomes': {
         '37': {
             'path': 'gs://gnomad-public/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {},
+            'custom_select': 'custom_gnomad_select'
         },
     },
     'gnomad_genome': {
         '37': {
             'path': 'gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {},
+            'custom_select': 'custom_gnomad_select'
         },
     },
     'exac': {
         '37': {
             'path': 'gs://seqr-reference-data/GRCh37/TopMed/bravo-dbsnp-all.removed_chr_prefix.liftunder_GRCh37.ht',
-            'selection': {'AC': 'info.AC'},
+            'select': {'AC': 'info.AC'},
         },
     },
 
 }
+
+def custom_gnomad_select(ht):
+    selects = {}
+    global_idx = hl.eval(ht.globals.freq_index_dict['gnomad'])
+    selects['AF'] = ht.freq[global_idx].AF
+    selects['AN'] = ht.freq[global_idx].AN
+    selects['AC'] = ht.freq[global_idx].AC
+    selects['hom'] = ht.freq[global_idx].homozygote_count
+
+    selects['POPMAX_AF'] = ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF
+    selects['hemi'] = hl.cond(ht.locus.in_autosome_or_par(),
+                              0, ht.freq[ht.globals.freq_index_dict['gnomad_male']].AC)
+    return selects
 
 def get_mt(dataset, reference_genome):
     config = CONFIG[dataset][reference_genome]
@@ -128,15 +143,23 @@ def get_mt(dataset, reference_genome):
     base_ht = hl.read_table(config['path'])
 
     field_name = config.get('field_name') or dataset
-    if isinstance(config['selection'], list):
-        select_fields = {selection: base_ht[selection] for selection in config['selection'] }
-    elif isinstance(config['selection'], dict):
+    if isinstance(config['select'], list):
+        select_fields = {selection: base_ht[selection] for selection in config['select'] }
+    elif isinstance(config['select'], dict):
         select_fields = {}
-        for key, val in config['selection'].items():
+        for key, val in config['select'].items():
             ht = base_ht
             for attr in val.split('.'):
-                ht = ht[attr]
+                if attr.endswith('#'):
+                    attr = attr[:-1]
+                    ht = ht[attr][base_ht.a_index-1]
+                else:
+                    ht = ht[attr]
             select_fields[key] = ht
+
+    if 'custom_select' in config:
+        custom_select_fn_str = config['custom_select']
+        select_fields = {**select_fields, **globals()[custom_select_fn_str](base_ht)}
 
     print(select_fields)
     select_query = {
@@ -156,12 +179,13 @@ def join_mts(datasets, reference_genome):
             joined_mt = joined_mt.join(dataset_mt)
     joined_mt.describe()
     print(os.path.join(OUTPUT_DIR, 'combined-%s.ht' % '-'.join(datasets)))
-    # joined_mt.write(os.path.join(OUTPUT_DIR, 'combined%s.ht' % combined_str))
+    joined_mt.write(os.path.join(OUTPUT_DIR, 'combined%s.ht' % '-'.join(datasets)))
 
 def run():
-    join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai'],
-             '37')
-    join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai'],
-             '38')
+    # join_mts(['1kg'], '37')
+    join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai', 'gnomad_genome', 'gnomad_exomes'],
+              '37')
+    # join_mts(['1kg', 'mpc', 'cadd', 'eigen', 'dbnsfp', 'topmed', 'primate_ai', 'splice_ai'],
+    #          '38')
 
 run()


### PR DESCRIPTION
Combining all seqr reference data into one combined dataset. This is a rewrite of  https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/download_and_create_reference_datasets/v01/hail_scripts/combine_all_variant_level_reference_data.py.

### Improvements
- Everything done in one step and no intermediary files.
- With outer joins we don't have to do a 2 step process of generating the union of variants from all datasets and annotating them one by one
- Instead of having individual functions for each dataset that fetched its own fields, there's a config with a generic syntax for selecting annotations
- Removed exclude individual dataset logic (and instead, select on specific datasets to run)

# Testing
Since we used new gnomad datasets (2.1.1 vs. 2.0.2), the combined data is not identical and an exact count sanity check cannot be done. However, the counts are close and are reasonable considering the added variants from gnomad https://docs.google.com/spreadsheets/d/1qHyQhZMhViT0McQ3TyB0EdVjpLUqJq4wWAfm_ackhhw/edit#gid=0.

V01
```

         Samples: 0
        Variants: 8657527985
       Call Rate: nan
         Contigs: ['X', '12', '8', '19', '4', '15', '11', '9', 'Y', '22', '13', '16', '5', '10', '21', '6', '1', '17', '14', '20', '2', '18', '7', '3']
   Multiallelics: 0
            SNPs: 8576020113
            MNPs: 2609239
      Insertions: 29242938
       Deletions: 46614438
 Complex Alleles: 3041257
    Star Alleles: 0
     Max Alleles: 2
```

V02
```
'==============================
Number of variants: 8657820153
==============================
Alleles per variant
-------------------
  2 alleles: 8657820153 variants
==============================
Variants per contig
-------------------
   1: 682247951 variants
   2: 721367831 variants
   3: 589856942 variants
   4: 568340246 variants
   5: 538050957 variants
   6: 506999424 variants
   7: 470723279 variants
   8: 432696742 variants
   9: 363827693 variants
  10: 397888458 variants
  11: 397105121 variants
  12: 395320276 variants
  13: 289543190 variants
  14: 267455272 variants
  15: 247503880 variants
  16: 239162095 variants
  17: 235919484 variants
  18: 226106399 variants
  19: 169554775 variants
  20: 180243501 variants
  21: 106424435 variants
  22: 105822167 variants
   X: 456668087 variants
   Y: 68991948 variants
==============================
Allele type distribution
------------------------
        SNP: 8575982091 alternate alleles
   Deletion: 46820464 alternate alleles
  Insertion: 29367097 alternate alleles
    Complex: 3041262 alternate alleles
        MNP: 2609239 alternate alleles
=============================='
```

Also, hemi count > 0 is close (`4,804,694` vs. `4,854,252`) which is important since this is not provided by new gnomad and has to be computed.

I did a quick sanity check by manually comparing 4 variants from both and the fields are the same. Not exhaustive, but validating this has not been pain-free.