### PR TITLE
seqr models

### DIFF
--- a/luigi_pipeline/README.md
+++ b/luigi_pipeline/README.md
@@ -10,7 +10,7 @@ $ pip install -r requirements.txt
 ### Tests
 ```
 $ pip install nose
-$ nosetests
+$ PYTHONPATH=.. nosetests
 ```
 
 ### Run

--- a/luigi_pipeline/lib/model/base_mt_schema.py
+++ b/luigi_pipeline/lib/model/base_mt_schema.py
@@ -12,11 +12,12 @@ def mt_annotation(annotation=None, fn_require=None):
         def a(self):
             return 'a_val'
 
-        @mt_annotation(annotation='b', fn_require='a')
+        @mt_annotation(annotation='b', fn_require=a)
         def b_1(self):
             return 'b_val'
 
     Will generate a mt with rows of {a: 'a_val', 'b': 'b_val'} if the function is called.
+    TODO: Consider changing fn_require to be a list of requirements.
 
     :param annotation: name in the final MT. If not provided, uses the function name.
     :param fn_require: method name strings in class that are dependencies.
@@ -31,7 +32,7 @@ def mt_annotation(annotation=None, fn_require=None):
             if wrapper.mt_prop_meta['annotated'] > 0:
                 return self
             if fn_require:
-                getattr(self, fn_require)()
+                getattr(self, fn_require.__name__)()
 
             # Annotate and retiurn instance for chaining.
             self.mt = self.mt.annotate_rows(**{annotation_name: func(self, *args, **kwargs)})
@@ -62,13 +63,13 @@ class BaseMTSchema:
             def a(self):
                 return 0
 
-            @mt_annotation(fn_require='a')
+            @mt_annotation(fn_require=a)
             def b(self):
-                return 1
+                return self.a + 1
 
-            @mt_annotation(annotation='c', fn_require='a')
+            @mt_annotation(annotation='c', fn_require=a)
             def c_1(self):
-                return 2
+                return self.a + 2
 
     `TestSchema(mt).b().c_1().select_annotated_mt()` will annotate with {'a': 0, 'b': 1, 'c': 2}
 

--- a/luigi_pipeline/lib/model/base_mt_schema.py
+++ b/luigi_pipeline/lib/model/base_mt_schema.py
@@ -1,0 +1,104 @@
+from abc import abstractmethod
+from inspect import getmembers, isfunction
+from functools import wraps
+
+
+def mt_annotation(annotation=None, fn_require=None):
+    """
+    Function decorator for methods in a subclass of BaseMTSchema.
+    Allows the function to be treated like an mt_annotation with annotation name and value.
+
+        @mt_annotation()
+        def a(self):
+            return 'a_val'
+
+        @mt_annotation(annotation='b', fn_require='a')
+        def b_1(self):
+            return 'b_val'
+
+    Will generate a mt with rows of {a: 'a_val', 'b': 'b_val'} if the function is called.
+
+    :param annotation: name in the final MT. If not provided, uses the function name.
+    :param fn_require: method name strings in class that are dependencies.
+    :return:
+    """
+    def mt_prop_wrapper(func):
+        annotation_name = annotation or func.__name__
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            # Called already.
+            if wrapper.mt_prop_meta['annotated'] > 0:
+                return self
+            if fn_require:
+                getattr(self, fn_require)()
+
+            # Annotate and retiurn instance for chaining.
+            self.mt = self.mt.annotate_rows(**{annotation_name: func(self, *args, **kwargs)})
+            wrapper.mt_prop_meta['annotated'] += 1
+            return self
+
+        wrapper.mt_prop_meta = {
+            'annotated': 0,  # Counter for number of times called. Should only be 0 or 1.
+            'annotated_name': annotation_name
+        }
+        return wrapper
+    return mt_prop_wrapper
+
+
+class BaseMTSchema:
+    """
+    Main superclass that provides a Hail MT schema definition. decorate methods with @mt_annotation.
+    Allows annotations to express dependencies where dependencies are run before (and at most once).
+    NOTE: circular dependencies are not supported and not gracefully handled.
+
+    Usage example:
+        class TestSchema(BaseMTSchema):
+
+            def __init__(self):
+                super(TestSchema, self).__init__(hl.import_vcf('tests/data/1kg_30variants.vcf.bgz'))
+
+            @mt_annotation()
+            def a(self):
+                return 0
+
+            @mt_annotation(fn_require='a')
+            def b(self):
+                return 1
+
+            @mt_annotation(annotation='c', fn_require='a')
+            def c_1(self):
+                return 2
+
+    `TestSchema(mt).b().c_1().select_annotated_mt()` will annotate with {'a': 0, 'b': 1, 'c': 2}
+
+    """
+    def __init__(self, mt):
+        self.mt = mt
+
+    def all_annotation_fns(self):
+        """
+        Get all mt_annotation decorated methods using introspection.
+        :return: list of all annotation functions
+        """
+        return getmembers(self.__class__, lambda x: isfunction(x) and hasattr(x, 'mt_prop_meta'))
+
+    def annotate_all(self):
+        """
+        Iterate over all annotation functions and call them on the instance.
+        :return: instance object
+        """
+        for atn_fn in self.all_annotation_fns():
+            getattr(self, atn_fn[0])()
+        return self
+
+    def select_annotated_mt(self):
+        """
+        Returns a matrix table with an annotated rows where each row annotation is a previously called
+        annotation (e.g. with the corresponding method or all in case of `annotate_all`).
+        :return: a matrix table
+        """
+        # Selection field is the annotation name of any function that has been called.
+        select_fields = [fn[1].mt_prop_meta['annotated_name'] for fn in self.all_annotation_fns() if
+                         'annotated_name' in fn[1].mt_prop_meta and fn[1].mt_prop_meta['annotated'] > 0]
+        return self.mt.select_rows(*select_fields)

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -1,117 +1,121 @@
 
 import hail as hl
 
-from lib.model.base_mt_schema import BaseMTSchema, mt_annotation
+from lib.model.base_mt_schema import BaseMTSchema, row_annotation
 from hail_scripts.v02.utils.computed_fields import variant_id
 from hail_scripts.v02.utils.computed_fields import vep
 
 
 class SeqrSchema(BaseMTSchema):
 
-    @mt_annotation(annotation='sortedTranscriptConsequences')
+    @row_annotation()
+    def vep(self):
+        return self.mt.vep
+
+    @row_annotation(name='sortedTranscriptConsequences', fn_require=vep)
     def sorted_transcript_consequences(self):
         return vep.get_expr_for_vep_sorted_transcript_consequences_array(self.mt.vep)
 
-    @mt_annotation(annotation='docId', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='docId')
     def doc_id(self, length=512):
         return variant_id.get_expr_for_variant_id(self.mt, length)
 
-    @mt_annotation(annotation='variantId', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='variantId')
     def variant_id(self):
         return variant_id.get_expr_for_variant_id(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def contig(self):
         return variant_id.get_expr_for_contig(self.mt.locus)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def pos(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def start(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def end(self):
         return variant_id.get_expr_for_end_pos(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def ref(self):
         return variant_id.get_expr_for_ref_allele(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def alt(self):
         return variant_id.get_expr_for_alt_allele(self.mt)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def xpos(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def xstart(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation()
     def xstop(self):
         return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt))
 
-    @mt_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation(fn_require=sorted_transcript_consequences)
     def domains(self):
         return vep.get_expr_for_vep_protein_domains_set_from_sorted(
             self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='transcriptConsequenceTerms', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='transcriptConsequenceTerms', fn_require=sorted_transcript_consequences)
     def transcript_consequence_terms(self):
         return vep.get_expr_for_vep_consequence_terms_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='transcriptIds', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='transcriptIds', fn_require=sorted_transcript_consequences)
     def transcript_ids(self):
         return vep.get_expr_for_vep_transcript_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='mainTranscript', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='mainTranscript', fn_require=sorted_transcript_consequences)
     def main_transcript(self):
         return vep.get_expr_for_worst_transcript_consequence_annotations_struct(
             self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='geneIds', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='geneIds', fn_require=sorted_transcript_consequences)
     def gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='codingGeneIds', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='codingGeneIds', fn_require=sorted_transcript_consequences)
     def coding_gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences, only_coding_genes=True)
 
 
 class SeqrVariantSchema(SeqrSchema):
 
-    @mt_annotation(annotation='AC')
+    @row_annotation(name='AC')
     def ac(self):
         return self.mt.info.AC
 
-    @mt_annotation(annotation='AF')
+    @row_annotation(name='AF')
     def af(self):
         return self.mt.info.AF
 
-    @mt_annotation(annotation='AN')
+    @row_annotation(name='AN')
     def an(self):
         return self.mt.info.AN
 
 
 class SeqrSVSchema(SeqrSchema):
 
-    @mt_annotation(annotation='IMPRECISE')
+    @row_annotation(name='IMPRECISE')
     def imprecise(self):
         return self.mt.info.IMPRECISE
 
-    @mt_annotation(annotation='SVTYPE')
+    @row_annotation(name='SVTYPE')
     def svtype(self):
         return self.mt.info.SVTYPE
 
-    @mt_annotation(annotation='SVLEN')
+    @row_annotation(name='SVLEN')
     def svlen(self):
         return self.mt.info.SVLEN
 
-    @mt_annotation(annotation='END')
+    @row_annotation(name='END')
     def end(self):
         return self.mt.info.END

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -12,73 +12,73 @@ class SeqrSchema(BaseMTSchema):
     def sorted_transcript_consequences(self):
         return vep.get_expr_for_vep_sorted_transcript_consequences_array(self.mt.vep)
 
-    @mt_annotation(annotation='docId', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='docId', fn_require=sorted_transcript_consequences)
     def doc_id(self, length=512):
         return variant_id.get_expr_for_variant_id(self.mt, length)
 
-    @mt_annotation(annotation='variantId', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='variantId', fn_require=sorted_transcript_consequences)
     def variant_id(self):
         return variant_id.get_expr_for_variant_id(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def contig(self):
         return variant_id.get_expr_for_contig(self.mt.locus)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def pos(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def start(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def end(self):
         return variant_id.get_expr_for_end_pos(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def ref(self):
         return variant_id.get_expr_for_ref_allele(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def alt(self):
         return variant_id.get_expr_for_alt_allele(self.mt)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def xpos(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def xstart(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def xstop(self):
         return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt))
 
-    @mt_annotation(fn_require='sorted_transcript_consequences')
+    @mt_annotation(fn_require=sorted_transcript_consequences)
     def domains(self):
         return vep.get_expr_for_vep_protein_domains_set_from_sorted(
             self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='transcriptConsequenceTerms', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='transcriptConsequenceTerms', fn_require=sorted_transcript_consequences)
     def transcript_consequence_terms(self):
         return vep.get_expr_for_vep_consequence_terms_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='transcriptIds', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='transcriptIds', fn_require=sorted_transcript_consequences)
     def transcript_ids(self):
         return vep.get_expr_for_vep_transcript_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='mainTranscript', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='mainTranscript', fn_require=sorted_transcript_consequences)
     def main_transcript(self):
         return vep.get_expr_for_worst_transcript_consequence_annotations_struct(
             self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='geneIds', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='geneIds', fn_require=sorted_transcript_consequences)
     def gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @mt_annotation(annotation='codingGeneIds', fn_require='sorted_transcript_consequences')
+    @mt_annotation(annotation='codingGeneIds', fn_require=sorted_transcript_consequences)
     def coding_gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences, only_coding_genes=True)
 

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -1,0 +1,117 @@
+
+import hail as hl
+
+from lib.model.base_mt_schema import BaseMTSchema, mt_annotation
+from hail_scripts.v02.utils.computed_fields import variant_id
+from hail_scripts.v02.utils.computed_fields import vep
+
+
+class SeqrSchema(BaseMTSchema):
+
+    @mt_annotation(annotation='sortedTranscriptConsequences')
+    def sorted_transcript_consequences(self):
+        return vep.get_expr_for_vep_sorted_transcript_consequences_array(self.mt.vep)
+
+    @mt_annotation(annotation='docId', fn_require='sorted_transcript_consequences')
+    def doc_id(self, length=512):
+        return variant_id.get_expr_for_variant_id(self.mt, length)
+
+    @mt_annotation(annotation='variantId', fn_require='sorted_transcript_consequences')
+    def variant_id(self):
+        return variant_id.get_expr_for_variant_id(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def contig(self):
+        return variant_id.get_expr_for_contig(self.mt.locus)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def pos(self):
+        return variant_id.get_expr_for_start_pos(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def start(self):
+        return variant_id.get_expr_for_start_pos(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def end(self):
+        return variant_id.get_expr_for_end_pos(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def ref(self):
+        return variant_id.get_expr_for_ref_allele(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def alt(self):
+        return variant_id.get_expr_for_alt_allele(self.mt)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def xpos(self):
+        return variant_id.get_expr_for_xpos(self.mt.locus)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def xstart(self):
+        return variant_id.get_expr_for_xpos(self.mt.locus)
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def xstop(self):
+        return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt))
+
+    @mt_annotation(fn_require='sorted_transcript_consequences')
+    def domains(self):
+        return vep.get_expr_for_vep_protein_domains_set_from_sorted(
+            self.mt.sortedTranscriptConsequences)
+
+    @mt_annotation(annotation='transcriptConsequenceTerms', fn_require='sorted_transcript_consequences')
+    def transcript_consequence_terms(self):
+        return vep.get_expr_for_vep_consequence_terms_set(self.mt.sortedTranscriptConsequences)
+
+    @mt_annotation(annotation='transcriptIds', fn_require='sorted_transcript_consequences')
+    def transcript_ids(self):
+        return vep.get_expr_for_vep_transcript_ids_set(self.mt.sortedTranscriptConsequences)
+
+    @mt_annotation(annotation='mainTranscript', fn_require='sorted_transcript_consequences')
+    def main_transcript(self):
+        return vep.get_expr_for_worst_transcript_consequence_annotations_struct(
+            self.mt.sortedTranscriptConsequences)
+
+    @mt_annotation(annotation='geneIds', fn_require='sorted_transcript_consequences')
+    def gene_ids(self):
+        return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences)
+
+    @mt_annotation(annotation='codingGeneIds', fn_require='sorted_transcript_consequences')
+    def coding_gene_ids(self):
+        return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences, only_coding_genes=True)
+
+
+class SeqrVariantSchema(SeqrSchema):
+
+    @mt_annotation(annotation='AC')
+    def ac(self):
+        return self.mt.info.AC
+
+    @mt_annotation(annotation='AF')
+    def af(self):
+        return self.mt.info.AF
+
+    @mt_annotation(annotation='AN')
+    def an(self):
+        return self.mt.info.AN
+
+
+class SeqrSVSchema(SeqrSchema):
+
+    @mt_annotation(annotation='IMPRECISE')
+    def imprecise(self):
+        return self.mt.info.IMPRECISE
+
+    @mt_annotation(annotation='SVTYPE')
+    def svtype(self):
+        return self.mt.info.SVTYPE
+
+    @mt_annotation(annotation='SVLEN')
+    def svlen(self):
+        return self.mt.info.SVLEN
+
+    @mt_annotation(annotation='END')
+    def end(self):
+        return self.mt.info.END

--- a/luigi_pipeline/tests/model/test_base_model.py
+++ b/luigi_pipeline/tests/model/test_base_model.py
@@ -1,0 +1,78 @@
+import unittest
+
+import hail as hl
+
+from lib.model.base_mt_schema import BaseMTSchema, mt_annotation
+
+class TestBaseModel(unittest.TestCase):
+
+    def _test_schema_class(self):
+        class TestSchema(BaseMTSchema):
+
+            def __init__(self):
+                super(TestSchema, self).__init__(hl.import_vcf('tests/data/1kg_30variants.vcf.bgz'))
+
+            @mt_annotation()
+            def a(self):
+                return 0
+
+            @mt_annotation(fn_require='a')
+            def b(self):
+                return self.mt.a + 1
+
+            @mt_annotation(annotation='c', fn_require='a')
+            def c_1(self):
+                return self.mt.a + 2
+
+        return TestSchema
+
+    def test_schema_called_once_counts(self):
+        test_schema = self._test_schema_class()()
+        test_schema.a()
+        fns = test_schema.all_annotation_fns()
+        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        self.assertEqual(count_dict, {'a': 1, 'b': 0, 'c_1': 0})
+
+    def test_schema_independent_counters(self):
+        test_schema = self._test_schema_class()()
+        test_schema.a()
+
+        test_schema2 = self._test_schema_class()()
+        test_schema2.b()
+
+        fns = test_schema.all_annotation_fns()
+        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        self.assertEqual(count_dict, {'a': 1, 'b': 0, 'c_1': 0})
+
+    def test_schema_dependencies(self):
+        test_schema = self._test_schema_class()()
+        test_schema.b()
+
+        fns = test_schema.all_annotation_fns()
+        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 0})
+
+    def test_schema_called_at_most_once(self):
+        test_schema = self._test_schema_class()()
+        test_schema.a().b().c_1()
+
+        fns = test_schema.all_annotation_fns()
+        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1})
+
+    def test_schema_annotate_all(self):
+        test_schema = self._test_schema_class()()
+        test_schema.a().annotate_all()
+
+        fns = test_schema.all_annotation_fns()
+        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1})
+
+    def test_schema_mt_select_annotated_mt(self):
+        test_schema = self._test_schema_class()()
+        mt = test_schema.a().annotate_all().select_annotated_mt()
+        first_row = mt.rows().take(1)[0]
+
+        self.assertEqual(first_row.a, 0)
+        self.assertEqual(first_row.b, 1)
+        self.assertEqual(first_row.c, 2)

--- a/luigi_pipeline/tests/model/test_base_model.py
+++ b/luigi_pipeline/tests/model/test_base_model.py
@@ -16,11 +16,11 @@ class TestBaseModel(unittest.TestCase):
             def a(self):
                 return 0
 
-            @mt_annotation(fn_require='a')
+            @mt_annotation(fn_require=a)
             def b(self):
                 return self.mt.a + 1
 
-            @mt_annotation(annotation='c', fn_require='a')
+            @mt_annotation(annotation='c', fn_require=a)
             def c_1(self):
                 return self.mt.a + 2
 

--- a/luigi_pipeline/tests/model/test_seqr_mt_schema.py
+++ b/luigi_pipeline/tests/model/test_seqr_mt_schema.py
@@ -1,0 +1,31 @@
+import unittest
+
+import hail as hl
+
+from lib.model.seqr_mt_schema import SeqrVariantSchema
+from tests.data.sample_vep import VEP_DATA, DERIVED_DATA
+
+class TestSeqrModel(unittest.TestCase):
+
+    def test_variant_derived_fields(self):
+        rsid = 'rs35471880'
+
+        mt = hl.import_vcf('tests/data/1kg_30variants.vcf.bgz')
+        mt = hl.split_multi(mt.filter_rows(mt.rsid == rsid))
+        mt = mt.annotate_rows(**VEP_DATA[rsid])
+
+        seqr_schema = SeqrVariantSchema(mt)
+        seqr_schema.sorted_transcript_consequences().doc_id(512).variant_id().contig().pos().start().end().ref().alt() \
+            .pos().xstart().xstop().xpos().transcript_consequence_terms().transcript_ids().main_transcript().gene_ids() \
+            .coding_gene_ids().domains().ac().af().an()
+        mt = seqr_schema.select_annotated_mt()
+
+        obj = mt.rows().collect()[0]
+
+        # Cannot do a nested compare because of nested hail objects, so do one by one.
+        fields = ['AC', 'AF', 'AN', 'codingGeneIds', 'docId', 'domains', 'end', 'geneIds', 'ref', 'alt', 'start',
+                  'variantId', 'transcriptIds', 'xpos', 'xstart', 'xstop', 'contig']
+        for field in fields:
+            self.assertEqual(obj[field], DERIVED_DATA[rsid][field])
+
+        self.assertEqual(obj['mainTranscript']['transcript_id'], DERIVED_DATA[rsid]['mainTranscript']['transcript_id'])

--- a/luigi_pipeline/tests/test_seqr_loading_tasks.py
+++ b/luigi_pipeline/tests/test_seqr_loading_tasks.py
@@ -51,21 +51,3 @@ class TestSeqrLoadingTasks(unittest.TestCase):
         # Supposed to be WGS but we report as WES.
         mock_sample_type_stats.return_value = self._sample_type_stats_return_value(0, 0, True, 0, 0, True)
         self.assertRaises(SeqrValidationError, SeqrVCFToMTTask.validate_mt, None, '37', 'WES')
-
-    def test_derive_fields(self):
-        rsid = 'rs35471880'
-
-        mt = hl.import_vcf(TEST_DATA_MT_1KG)
-        mt = hl.split_multi(mt.filter_rows(mt.rsid == rsid))
-        mt = mt.annotate_rows(**VEP_DATA[rsid])
-        mt = SeqrVCFToMTTask.derive_fields(mt, 'VARIANTS')
-
-        obj = mt.rows().collect()[0]
-
-        # Cannot do a nested compare because of nested hail objects, so do one by one.
-        fields = ['AC', 'AF', 'AN', 'codingGeneIds', 'docId', 'domains', 'end', 'geneIds', 'ref', 'alt', 'start',
-                  'variantId', 'transcriptIds', 'xpos', 'xstart', 'xstop', 'contig']
-        for field in fields:
-            self.assertEqual(obj[field], DERIVED_DATA[rsid][field])
-
-        self.assertEqual(obj['mainTranscript']['transcript_id'], DERIVED_DATA[rsid]['mainTranscript']['transcript_id'])


### PR DESCRIPTION
tldr;
Fun stuff, introducing matrix table schemas
- clearly define annotation schema with fields and their values
- centralized so the logic is clearer
- express dependencies between annotations
- allow different types of schema to share annotation definitions but branch
- more easy to do validations and ensure correctness (TODO, with hail and ES types)

**----- The sell ----**
Are you like me, folks? Do you find yourself having a hard time tracking all of the seqr annotations across a long pipeline and from many different sources? Sometimes different tables storing different data should have slightly different annotations while sharing common ones, but the branching logic is just scattered. Other times, annotations depend on other annotations, so you have to order them. Introducing schema models!
**-----------**

Example:

```
        class TestSchema(BaseMTSchema):

            @mt_annotation()
            def a(self):
                return 0
            
            # depend on a
            @mt_annotation(fn_require='a')
            def b(self):
                return self.mt.a + 1

            # by default, use function name as annotation name but can override with `annotation=` 
            @mt_annotation(annotation='c', fn_require='a')
            def c_1(self):
                return self.mt.a + 2
```

Usage:
```
schema = TestSchema(mt)
schema.b() # annotates() `a` then`b` because of `fn_require='a'`.
schema.c() # will not call `a` again
mt = schema.select_annotated_mt() # return a matrix table with rows of only selected annotations.
## $ PROFIT. Also option to annotate all at once.
```

For our use case, I found it hard to track down all of the annotations across `variant` and `sv` types, then derived fields going off of vep and sortedtranscipt field, and later the reference data as well as annotations from genotypes. Having a clearly defined schema seems like it would make validation and code readability/maintainability.