### PR TITLE
v02 genotypes

### DIFF
--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -6,7 +6,7 @@ import hail as hl
 from lib.hail_tasks import HailMatrixTableTask, HailElasticSearchTask, GCSorLocalTarget
 from hail_scripts.v02.utils.computed_fields import variant_id
 from hail_scripts.v02.utils.computed_fields import vep
-from lib.model.seqr_mt_schema import SeqrVariantSchema, SeqrSVSchema
+from lib.model.seqr_mt_schema import SeqrVariantSchema
 
 logger = logging.getLogger(__name__)
 

--- a/luigi_pipeline/tests/model/test_base_model.py
+++ b/luigi_pipeline/tests/model/test_base_model.py
@@ -4,72 +4,73 @@ import hail as hl
 
 from lib.model.base_mt_schema import BaseMTSchema, row_annotation
 
+
 class TestBaseModel(unittest.TestCase):
 
-    def _test_schema_class(self):
-        class TestSchema(BaseMTSchema):
+    class TestSchema(BaseMTSchema):
 
-            def __init__(self):
-                super(TestSchema, self).__init__(hl.import_vcf('tests/data/1kg_30variants.vcf.bgz'))
+        def __init__(self):
+            super(TestBaseModel.TestSchema, self).__init__(hl.import_vcf('tests/data/1kg_30variants.vcf.bgz'))
 
-            @row_annotation()
-            def a(self):
-                return 0
+        @row_annotation()
+        def a(self):
+            return 0
 
-            @row_annotation(fn_require=a)
-            def b(self):
-                return self.mt.a + 1
+        @row_annotation(fn_require=a)
+        def b(self):
+            return self.mt.a + 1
 
-            @row_annotation(name='c', fn_require=a)
-            def c_1(self):
-                return self.mt.a + 2
+        @row_annotation(name='c', fn_require=a)
+        def c_1(self):
+            return self.mt.a + 2
 
-        return TestSchema
+    def _count_dicts(self, schema):
+        return {
+            k: v['annotated']
+            for k, v in schema.mt_instance_meta['row_annotations'].items()
+        }
 
     def test_schema_called_once_counts(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         test_schema.a()
         fns = test_schema.all_annotation_fns()
-        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
-        self.assertEqual(count_dict, {'a': 1, 'b': 0, 'c_1': 0})
+
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'a': 1})
 
     def test_schema_independent_counters(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         test_schema.a()
 
-        test_schema2 = self._test_schema_class()()
+        test_schema2 = TestBaseModel.TestSchema()
         test_schema2.b()
 
-        fns = test_schema.all_annotation_fns()
-        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
-        self.assertEqual(count_dict, {'a': 1, 'b': 0, 'c_1': 0})
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'a': 1})
 
     def test_schema_dependencies(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         test_schema.b()
 
-        fns = test_schema.all_annotation_fns()
-        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
-        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 0})
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'a': 1, 'b': 1})
 
     def test_schema_called_at_most_once(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         test_schema.a().b().c_1()
 
-        fns = test_schema.all_annotation_fns()
-        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        count_dict = self._count_dicts(test_schema)
         self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1})
 
     def test_schema_annotate_all(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         test_schema.annotate_all()
 
-        fns = test_schema.all_annotation_fns()
-        count_dict = {fn[0]: fn[1].mt_prop_meta['annotated'] for fn in fns}
+        count_dict = self._count_dicts(test_schema)
         self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1})
 
     def test_schema_mt_select_annotated_mt(self):
-        test_schema = self._test_schema_class()()
+        test_schema = TestBaseModel.TestSchema()
         mt = test_schema.annotate_all().select_annotated_mt()
         first_row = mt.rows().take(1)[0]
 
@@ -99,6 +100,44 @@ class TestBaseModel(unittest.TestCase):
                 def a(self):
                     return 0
         except ValueError as e:
-            self.assertEqual(str(e), 'Schema: dependency dummy is not a method within class TestSchema.')
+            self.assertEqual(str(e), 'Schema: dependency dummy is not a row annotation method.')
             return True
         self.fail('Did not raise ValueError.')
+
+    def test_inheritance(self):
+        class TestSchemaChild(TestBaseModel.TestSchema):
+
+            @row_annotation(fn_require=TestBaseModel.TestSchema.a)
+            def d(self):
+                return self.mt.a + 4
+
+        test_schema = TestSchemaChild()
+        mt = test_schema.d().select_annotated_mt()
+        first_row = mt.rows().take(1)[0]
+
+        self.assertEqual(first_row.a, 0)
+        self.assertEqual(first_row.d, 4)
+
+    def test_multi_annotation(self):
+        class TestSchema2(TestBaseModel.TestSchema):
+
+            @row_annotation(multi_annotation=True)
+            def multi(self):
+                return {'a': 1, 'b': 2}
+
+        mt = TestSchema2().multi().select_annotated_mt()
+        first_row = mt.rows().take(1)[0]
+
+        self.assertEqual(first_row.a, 1)
+        self.assertEqual(first_row.b, 2)
+
+    def test_multi_annotation_fail(self):
+        class TestSchema2(TestBaseModel.TestSchema):
+
+            @row_annotation(multi_annotation=True)
+            def multi(self):
+                return 3
+
+        test_schema = TestSchema2()
+        self.assertRaises(ValueError, test_schema.multi)
+

--- a/luigi_pipeline/tests/model/test_seqr_mt_schema.py
+++ b/luigi_pipeline/tests/model/test_seqr_mt_schema.py
@@ -7,17 +7,19 @@ from tests.data.sample_vep import VEP_DATA, DERIVED_DATA
 
 class TestSeqrModel(unittest.TestCase):
 
-    def test_variant_derived_fields(self):
-        rsid = 'rs35471880'
-
+    def _get_filtered_mt(self, rsid='rs35471880'):
         mt = hl.import_vcf('tests/data/1kg_30variants.vcf.bgz')
         mt = hl.split_multi(mt.filter_rows(mt.rsid == rsid))
-        mt = mt.annotate_rows(**VEP_DATA[rsid])
+        return mt
+
+    def test_variant_derived_fields(self):
+        rsid = 'rs35471880'
+        mt = self._get_filtered_mt(rsid).annotate_rows(**VEP_DATA[rsid])
 
         seqr_schema = SeqrVariantSchema(mt)
         seqr_schema.sorted_transcript_consequences().doc_id(512).variant_id().contig().pos().start().end().ref().alt() \
             .pos().xstart().xstop().xpos().transcript_consequence_terms().transcript_ids().main_transcript().gene_ids() \
-            .coding_gene_ids().domains().ac().af().an()
+            .coding_gene_ids().domains().ac().af().an().annotate_all()
         mt = seqr_schema.select_annotated_mt()
 
         obj = mt.rows().collect()[0]
@@ -29,3 +31,89 @@ class TestSeqrModel(unittest.TestCase):
             self.assertEqual(obj[field], DERIVED_DATA[rsid][field])
 
         self.assertEqual(obj['mainTranscript']['transcript_id'], DERIVED_DATA[rsid]['mainTranscript']['transcript_id'])
+
+    def test_variant_genotypes(self):
+        mt = self._get_filtered_mt()
+        seqr_schema = SeqrVariantSchema(mt)
+
+        mt = seqr_schema.genotypes().select_annotated_mt()
+        genotypes = mt.rows().collect()[0].genotypes
+        actual = {gen['sample_id']: dict(gen) for gen in genotypes}
+
+        expected = {'HG00731': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 73.0, 'sample_id': 'HG00731'},
+                    'HG00732': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 70.0, 'sample_id': 'HG00732'},
+                    'HG00733': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 66.0, 'sample_id': 'HG00733'},
+                    'NA19675': {'num_alt': 1, 'gq': 99, 'ab': 0.6000000238418579, 'dp': 29.0,
+                                'sample_id': 'NA19675'},
+                    'NA19678': {'num_alt': 0, 'gq': 78, 'ab': 0.0, 'dp': 28.0, 'sample_id': 'NA19678'},
+                    'NA19679': {'num_alt': 1, 'gq': 99, 'ab': 0.3571428656578064, 'dp': 27.0,
+                                'sample_id': 'NA19679'},
+                    'NA20870': {'num_alt': 1, 'gq': 99, 'ab': 0.5142857432365417, 'dp': 67.0,
+                                'sample_id': 'NA20870'},
+                    'NA20872': {'num_alt': 1, 'gq': 99, 'ab': 0.5066666603088379, 'dp': 74.0,
+                                'sample_id': 'NA20872'},
+                    'NA20874': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 69.0, 'sample_id': 'NA20874'},
+                    'NA20875': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 93.0, 'sample_id': 'NA20875'},
+                    'NA20876': {'num_alt': 1, 'gq': 99, 'ab': 0.4383561611175537, 'dp': 70.0,
+                                'sample_id': 'NA20876'},
+                    'NA20877': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 76.0, 'sample_id': 'NA20877'},
+                    'NA20878': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 73.0, 'sample_id': 'NA20878'},
+                    'NA20881': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 69.0, 'sample_id': 'NA20881'},
+                    'NA20885': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 82.0, 'sample_id': 'NA20885'},
+                    'NA20888': {'num_alt': 0, 'gq': 99, 'ab': 0.0, 'dp': 74.0, 'sample_id': 'NA20888'}}
+        self.assertEqual(actual, expected)
+
+    def test_samples_num_alt(self):
+        mt = self._get_filtered_mt()
+        seqr_schema = SeqrVariantSchema(mt)
+
+        mt = seqr_schema.samples_no_call().samples_num_alt().select_annotated_mt()
+        row = mt.rows().collect()[0]
+        self.assertEqual(row.samples_no_call, set())
+        self.assertEqual(row.samples_num_alt_1, {'NA19679', 'NA19675', 'NA20870', 'NA20876', 'NA20872'})
+        self.assertEqual(row.samples_num_alt_2, set())
+
+    def test_samples_gq(self):
+        non_empty = {
+            'samples_gq_75_to_80': {'NA19678'}
+        }
+        start = 0
+        end = 95
+        step = 5
+
+        mt = self._get_filtered_mt()
+        seqr_schema = SeqrVariantSchema(mt)
+
+        mt = seqr_schema.samples_gq(start, end, step).select_annotated_mt()
+        row = mt.rows().collect()[0]
+
+        for name, samples in non_empty.items():
+            self.assertEqual(row[name], samples)
+
+        for i in range(start, end, step):
+            name = 'samples_gq_%i_to_%i' % (i, i+step)
+            if name not in non_empty:
+                self.assertEqual(row[name], set())
+
+    def test_samples_ab(self):
+        non_empty = {
+            'samples_ab_35_to_40': {'NA19679'},
+            'samples_ab_40_to_45': {'NA20876'},
+        }
+        start = 0
+        end = 45
+        step = 5
+
+        mt = self._get_filtered_mt()
+        seqr_schema = SeqrVariantSchema(mt)
+
+        mt = seqr_schema.samples_ab(start, end, step).select_annotated_mt()
+        row = mt.rows().collect()[0]
+
+        for name, samples in non_empty.items():
+            self.assertEqual(row[name], samples)
+
+        for i in range(start, end, step):
+            name = 'samples_ab_%i_to_%i' % (i, i+step)
+            if name not in non_empty:
+                self.assertEqual(row[name], set())

--- a/luigi_pipeline/tests/test_seqr_loading_tasks.py
+++ b/luigi_pipeline/tests/test_seqr_loading_tasks.py
@@ -1,12 +1,11 @@
 import unittest
 from unittest.mock import patch
 
-import hail as hl
-
 from seqr_loading import SeqrVCFToMTTask, SeqrValidationError
 from tests.data.sample_vep import VEP_DATA, DERIVED_DATA
 
 TEST_DATA_MT_1KG = 'tests/data/1kg_30variants.vcf.bgz'
+
 
 class TestSeqrLoadingTasks(unittest.TestCase):
 


### PR DESCRIPTION
# Features
- bug fix for row_annotations decorator (save some state to instance and not class)
- removed SV schema for now until needed
- added multi_annotation boolean to row_annotations decorator so we can support annotating num_samples_gq_i_to_n more easily (I thought of writing each out, which I actually prefer so it's defined, but there are just so many...)

# Testing
- Tested against v01 implementation, where we found discrepancies in missing genotypes discussion https://discuss.hail.is/t/hail-v01-to-v02-missing-genotypes/939 and https://hail.zulipchat.com/. Pending consensus, but for non-missing genotypes, computations match. 
- Wrote tests cases off of one variant in the 1kg30

It's a lot of changes, so I'll only tag people in parts that they might be familiar with.