### PR TITLE
Kev/es export

### DIFF
--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -134,6 +134,24 @@ class SeqrVariantSchema(SeqrSchema):
             for i in range(start, end, step)
         })
 
+    def elasticsearch_row(self):
+        """
+        Prepares the mt to export using ElasticsearchClient V02.
+        - Flattens nested structs
+        - drops locus and alleles key
+
+        TODO:
+        - Call validate
+        - when all annotations are here, whitelist fields to send instead of blacklisting.
+        :return:
+        """
+        # Converts nested structs into one field, e.g. {a: {b: 1}} => a.b: 1
+        table = self.mt.rows().flatten()
+        # When flattening, the table is unkeyed, which causes problems because our locus and alleles should not
+        # be normal fields. We can also re-key, but I believe this is computational?
+        table = table.drop(table.locus, table.alleles)
+        return table
+
     def _genotype_filter_samples(self, filter):
         # Filter on the genotypes.
         return hl.set(self.mt.genotypes.filter(filter).map(lambda g: g.sample_id))

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -91,11 +91,11 @@ class SeqrVariantSchema(SeqrSchema):
 
     @row_annotation(name='AC')
     def ac(self):
-        return self.mt.info.AC
+        return self.mt.info.AC[self.mt.a_index-1]
 
     @row_annotation(name='AF')
     def af(self):
-        return self.mt.info.AF
+        return self.mt.info.AF[self.mt.a_index-1]
 
     @row_annotation(name='AN')
     def an(self):
@@ -109,31 +109,30 @@ class SeqrVariantSchema(SeqrSchema):
     def samples_no_call(self):
         return self._genotype_filter_samples(lambda g: g.num_alt == -1)
 
-    @row_annotation(fn_require=genotypes, multi_annotation=True)
+    @row_annotation(fn_require=genotypes)
     def samples_num_alt(self, start=1, end=3, step=1):
-        # NOTE: Multiple annotations.
-        return {
-            'samples_num_alt_%i' % i: self._genotype_filter_samples(lambda g: g.num_alt == i)
+        return hl.struct(**{
+            '%i' % i: self._genotype_filter_samples(lambda g: g.num_alt == i)
             for i in range(start, end, step)
-        }
+        })
 
-    @row_annotation(fn_require=genotypes, multi_annotation=True)
+    @row_annotation(fn_require=genotypes)
     def samples_gq(self, start=0, end=95, step=5):
-        # NOTE: Multiple annotations.
-        return {
-            'samples_gq_%i_to_%i' % (i, i+step): self._genotype_filter_samples(lambda g: ((g.gq >= i) & (g.gq < i+step)))
+        # struct of x_to_y to a set of samples in range of x and y for gq.
+        return hl.struct(**{
+            '%i_to_%i' % (i, i+step): self._genotype_filter_samples(lambda g: ((g.gq >= i) & (g.gq < i+step)))
             for i in range(start, end, step)
-        }
+        })
 
-    @row_annotation(fn_require=genotypes, multi_annotation=True)
+    @row_annotation(fn_require=genotypes)
     def samples_ab(self, start=0, end=45, step=5):
-        # NOTE: Multiple annotations.
-        return {
-            'samples_ab_%i_to_%i' % (i, i+step): self._genotype_filter_samples(
+        # struct of x_to_y to a set of samples in range of x and y for ab.
+        return hl.struct(**{
+            '%i_to_%i' % (i, i+step): self._genotype_filter_samples(
                 lambda g: ((g.num_alt == 1) & ((g.ab*100) >= i) & ((g.ab*100) < i+step))
             )
             for i in range(start, end, step)
-        }
+        })
 
     def _genotype_filter_samples(self, filter):
         # Filter on the genotypes.

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -3,9 +3,8 @@ import logging
 import luigi
 import hail as hl
 
+from hail_scripts.v02.utils.elasticsearch_client import ElasticsearchClient
 from lib.hail_tasks import HailMatrixTableTask, HailElasticSearchTask, GCSorLocalTarget, MatrixTableSampleSetError
-from hail_scripts.v02.utils.computed_fields import variant_id
-from hail_scripts.v02.utils.computed_fields import vep
 from lib.model.seqr_mt_schema import SeqrVariantSchema
 
 logger = logging.getLogger(__name__)
@@ -36,8 +35,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         mt = hl.split_multi(mt)
         mt = HailMatrixTableTask.run_vep(mt, self.genome_version, self.vep_runner)
 
-        Schema = SeqrVariantSchema if self.dataset_type == 'VARIANTS' else SeqrSVSchema
-        mt = Schema(mt).annotate_all().select_annotated_mt()
+        mt = SeqrVariantSchema(mt).annotate_all(overwrite=True).select_annotated_mt()
 
         mt.describe()
         mt.write(self.output().path)
@@ -104,8 +102,14 @@ class SeqrMTToESTask(HailElasticSearchTask):
     def run(self):
         # Right now it writes to a file, but will export to ES in the future.
         mt = self.import_mt()
-        with self.output().open('w') as out_file:
-            out_file.write('count: %i' % mt.count()[0])
+        # schema = SeqrVariantSchema(mt)
+        es = ElasticsearchClient()
+        table = mt.rows().flatten()
+        table = table.drop(table.locus, table.alleles)
+        es.export_table_to_elasticsearch(table)
+
+        # with self.output().open('w') as out_file:
+        #     out_file.write('count: %i' % mt.count()[0])
 
 
 if __name__ == '__main__':

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -100,16 +100,15 @@ class SeqrMTToESTask(HailElasticSearchTask):
         return GCSorLocalTarget(filename=self.dest_file)
 
     def run(self):
-        # Right now it writes to a file, but will export to ES in the future.
-        mt = self.import_mt()
-        # schema = SeqrVariantSchema(mt)
+        schema = SeqrVariantSchema(self.import_mt())
         es = ElasticsearchClient()
-        table = mt.rows().flatten()
-        table = table.drop(table.locus, table.alleles)
-        es.export_table_to_elasticsearch(table)
 
-        # with self.output().open('w') as out_file:
-        #     out_file.write('count: %i' % mt.count()[0])
+        row_table = schema.elasticsearch_row()
+        es.export_table_to_elasticsearch(row_table)
+
+        # This is just for debugging for now. Not needed since the ES export is the output.
+        with self.output().open('w') as out_file:
+            out_file.write('count: %i' % row_table.count())
 
 
 if __name__ == '__main__':

--- a/luigi_pipeline/tests/data/sample_vep.py
+++ b/luigi_pipeline/tests/data/sample_vep.py
@@ -539,8 +539,8 @@ VEP_DATA = {
 
 # Derived from the vep annotated data (VEP_DATA).
 DERIVED_DATA = {
-    'rs35471880': {'AC': [5],
-                   'AF': [0.156],
+    'rs35471880': {'AC': 5,
+                   'AF': 0.156,
                    'AN': 32,
                    'a_index': 1,
                    'alleles': ['G', 'A'],

--- a/luigi_pipeline/tests/model/test_base_model.py
+++ b/luigi_pipeline/tests/model/test_base_model.py
@@ -141,3 +141,59 @@ class TestBaseModel(unittest.TestCase):
         test_schema = TestSchema2()
         self.assertRaises(ValueError, test_schema.multi)
 
+    def test_overwrite_default_false(self):
+        # info field is already in our mt.
+        class TestSchema(TestBaseModel.TestSchema):
+
+            @row_annotation()
+            def info(self):
+                return 0
+
+        # should not overwrite.
+        test_schema = TestSchema().info()
+
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'info': 0})
+
+    def test_overwrite_true(self):
+        # info field is already in our mt.
+        class TestSchema(TestBaseModel.TestSchema):
+
+            @row_annotation()
+            def info(self):
+                return 0
+
+        # should overwrite.
+        test_schema = TestSchema().info(overwrite=True)
+
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'info': 1})
+
+    def test_annotate_all_overwrite_defailt_false(self):
+        # info field is already in our mt.
+        class TestSchema(TestBaseModel.TestSchema):
+
+            @row_annotation()
+            def info(self):
+                return 0
+
+        # should overwrite.
+        test_schema = TestSchema().annotate_all()
+
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1, 'info': 0})
+
+    def test_annotate_all_overwrite_true(self):
+        # info field is already in our mt.
+        class TestSchema(TestBaseModel.TestSchema):
+
+            @row_annotation()
+            def info(self):
+                return 0
+
+        # should overwrite.
+        test_schema = TestSchema().annotate_all(overwrite=True)
+
+        count_dict = self._count_dicts(test_schema)
+        self.assertEqual(count_dict, {'a': 1, 'b': 1, 'c_1': 1, 'info': 1})
+

--- a/luigi_pipeline/tests/model/test_base_model.py
+++ b/luigi_pipeline/tests/model/test_base_model.py
@@ -118,29 +118,6 @@ class TestBaseModel(unittest.TestCase):
         self.assertEqual(first_row.a, 0)
         self.assertEqual(first_row.d, 4)
 
-    def test_multi_annotation(self):
-        class TestSchema2(TestBaseModel.TestSchema):
-
-            @row_annotation(multi_annotation=True)
-            def multi(self):
-                return {'a': 1, 'b': 2}
-
-        mt = TestSchema2().multi().select_annotated_mt()
-        first_row = mt.rows().take(1)[0]
-
-        self.assertEqual(first_row.a, 1)
-        self.assertEqual(first_row.b, 2)
-
-    def test_multi_annotation_fail(self):
-        class TestSchema2(TestBaseModel.TestSchema):
-
-            @row_annotation(multi_annotation=True)
-            def multi(self):
-                return 3
-
-        test_schema = TestSchema2()
-        self.assertRaises(ValueError, test_schema.multi)
-
     def test_overwrite_default_false(self):
         # info field is already in our mt.
         class TestSchema(TestBaseModel.TestSchema):

--- a/luigi_pipeline/tests/model/test_seqr_mt_schema.py
+++ b/luigi_pipeline/tests/model/test_seqr_mt_schema.py
@@ -68,14 +68,14 @@ class TestSeqrModel(unittest.TestCase):
         seqr_schema = SeqrVariantSchema(mt)
 
         mt = seqr_schema.samples_no_call().samples_num_alt().select_annotated_mt()
-        row = mt.rows().collect()[0]
+        row = mt.rows().flatten().collect()[0]
         self.assertEqual(row.samples_no_call, set())
-        self.assertEqual(row.samples_num_alt_1, {'NA19679', 'NA19675', 'NA20870', 'NA20876', 'NA20872'})
-        self.assertEqual(row.samples_num_alt_2, set())
+        self.assertEqual(row['samples_num_alt.1'], {'NA19679', 'NA19675', 'NA20870', 'NA20876', 'NA20872'})
+        self.assertEqual(row['samples_num_alt.2'], set())
 
     def test_samples_gq(self):
         non_empty = {
-            'samples_gq_75_to_80': {'NA19678'}
+            'samples_gq.75_to_80': {'NA19678'}
         }
         start = 0
         end = 95
@@ -85,20 +85,20 @@ class TestSeqrModel(unittest.TestCase):
         seqr_schema = SeqrVariantSchema(mt)
 
         mt = seqr_schema.samples_gq(start, end, step).select_annotated_mt()
-        row = mt.rows().collect()[0]
+        row = mt.rows().flatten().collect()[0]
 
         for name, samples in non_empty.items():
             self.assertEqual(row[name], samples)
 
         for i in range(start, end, step):
-            name = 'samples_gq_%i_to_%i' % (i, i+step)
+            name = 'samples_gq.%i_to_%i' % (i, i+step)
             if name not in non_empty:
                 self.assertEqual(row[name], set())
 
     def test_samples_ab(self):
         non_empty = {
-            'samples_ab_35_to_40': {'NA19679'},
-            'samples_ab_40_to_45': {'NA20876'},
+            'samples_ab.35_to_40': {'NA19679'},
+            'samples_ab.40_to_45': {'NA20876'},
         }
         start = 0
         end = 45
@@ -108,12 +108,12 @@ class TestSeqrModel(unittest.TestCase):
         seqr_schema = SeqrVariantSchema(mt)
 
         mt = seqr_schema.samples_ab(start, end, step).select_annotated_mt()
-        row = mt.rows().collect()[0]
+        row = mt.rows().flatten().collect()[0]
 
         for name, samples in non_empty.items():
             self.assertEqual(row[name], samples)
 
         for i in range(start, end, step):
-            name = 'samples_ab_%i_to_%i' % (i, i+step)
+            name = 'samples_ab.%i_to_%i' % (i, i+step)
             if name not in non_empty:
                 self.assertEqual(row[name], set())

--- a/luigi_pipeline/tests/model/test_seqr_mt_schema.py
+++ b/luigi_pipeline/tests/model/test_seqr_mt_schema.py
@@ -17,7 +17,7 @@ class TestSeqrModel(unittest.TestCase):
         mt = self._get_filtered_mt(rsid).annotate_rows(**VEP_DATA[rsid])
 
         seqr_schema = SeqrVariantSchema(mt)
-        seqr_schema.sorted_transcript_consequences().doc_id(512).variant_id().contig().pos().start().end().ref().alt() \
+        seqr_schema.sorted_transcript_consequences().doc_id(length=512).variant_id().contig().pos().start().end().ref().alt() \
             .pos().xstart().xstop().xpos().transcript_consequence_terms().transcript_ids().main_transcript().gene_ids() \
             .coding_gene_ids().domains().ac().af().an().annotate_all()
         mt = seqr_schema.select_annotated_mt()


### PR DESCRIPTION
A few things here:
- Changed behavior so by default, if an mt already has an annotation, calling annotate on that field will not do anything unless we manually overwrite that annotation. 
- Removed multi-annotation, which was introduced to support a way to generate many annotations, samples_ab_{x}\_to_{y} (a `row_annotation` decorated function that annotates multiple annotations). Then I found out that we can store it as `{samples_ab: {x_to_y: value}}` in the mt and we flatten the list so it becomes samples_ab_x_to_y when exporting to ES, so we would only need a single annotation.
- Added export logic. Things were made a lot easier with the elasticsearch v02 client (thanks @nawatts) that generates the types. Also, using the hail `flatten` function allows us to now have to implement it, which is what https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/8e4983a1bf402417ae571bcf06459fa032a83f10/hail_scripts/v01/utils/elasticsearch_client.py#L156-L163 is trying to do? @bw2 can you confirm?
- Only uses the nested objects, no more child-kt stuff

## TODO
- Reference data, in progress
- ES loading logic

Sorry another PR with a few things in one. I'll tag relevant people in relevant sections.

Sample ES output (@hanars we are still missing reference data annotations, but can you check that everything else looks like it's in the right format? I did a quick skim against seqr ES):
```
{
  "_index": "data",
  "_type": "variant",
  "_id": "7CSyUGoBaWYFgzNpptdM",
  "_score": 1,
  "_source": {
    "AC": 22,
    "AF": 0.688,
    "alt": "A",
    "AN": 32,
    "codingGeneIds": [
      "ENSG00000188976"
    ],
    "contig": "1",
    "docId": "1-881627-G-A",
    "domains": [
      "Pfam_domain:PF03715",
      "Superfamily_domains:SSF48371",
      "hmmpanther:PTHR12687"
    ],
    "end": 881628,
    "geneIds": [
      "ENSG00000188976"
    ],
    "genotypes": [
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 38,
        "sample_id": "HG00731_1"
      },
      {
        "num_alt": 0,
        "gq": 99,
        "ab": 0,
        "dp": 61,
        "sample_id": "HG00732"
      },
      {
        "num_alt": 1,
        "gq": 99,
        "ab": 0.4146341383457184,
        "dp": 38,
        "sample_id": "HG00733"
      },
      {
        "num_alt": 2,
        "gq": 48,
        "ab": 1,
        "dp": 16,
        "sample_id": "NA19675"
      },
      {
        "num_alt": 2,
        "gq": 54,
        "ab": 1,
        "dp": 18,
        "sample_id": "NA19678"
      },
      {
        "num_alt": 2,
        "gq": 66,
        "ab": 1,
        "dp": 25,
        "sample_id": "NA19679"
      },
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 51,
        "sample_id": "NA20870"
      },
      {
        "num_alt": 1,
        "gq": 99,
        "ab": 0.4791666567325592,
        "dp": 46,
        "sample_id": "NA20872"
      },
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 33,
        "sample_id": "NA20874"
      },
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 52,
        "sample_id": "NA20875"
      },
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 45,
        "sample_id": "NA20876"
      },
      {
        "num_alt": 1,
        "gq": 99,
        "ab": 0.5142857432365417,
        "dp": 34,
        "sample_id": "NA20878"
      },
      {
        "num_alt": 2,
        "gq": 99,
        "ab": 1,
        "dp": 44,
        "sample_id": "NA20881"
      }
    ],
    "mainTranscript_biotype": "protein_coding",
    "mainTranscript_canonical": 1,
    "mainTranscript_category": "missense",
    "mainTranscript_cdna_start": 1717,
    "mainTranscript_cdna_end": 1717,
    "mainTranscript_codons": "tCg/tTg",
    "mainTranscript_gene_id": "ENSG00000188976",
    "mainTranscript_gene_symbol": "NOC2L",
    "mainTranscript_hgvs": "p.Ser556Leu",
    "mainTranscript_hgvsc": "ENST00000327044.6:c.1667C>T",
    "mainTranscript_major_consequence": "missense_variant",
    "mainTranscript_major_consequence_rank": 11,
    "mainTranscript_transcript_id": "ENST00000327044",
    "mainTranscript_amino_acids": "S/L",
    "mainTranscript_domains": "Pfam_domain:PF03715,Superfamily_domains:SSF48371,hmmpanther:PTHR12687",
    "mainTranscript_hgvsp": "ENSP00000317992.6:p.Ser556Leu",
    "mainTranscript_lof_info": "INTRON_END:881781,EXON_END:881925,EXON_START:881782,DE_NOVO_DONOR_MES:-7.36719797135343,DE_NOVO_DONOR_PROB:0.261170618766552,DE_NOVO_DONOR_POS:-138,INTRON_START:881667,DE_NOVO_DONOR_MES_POS:-138,MUTANT_DONOR_MES:4.93863747168278",
    "mainTranscript_polyphen_prediction": "benign",
    "mainTranscript_protein_id": "ENSP00000317992",
    "mainTranscript_sift_prediction": "deleterious",
    "pos": 881627,
    "ref": "G",
    "samples_ab_0_to_5": [],
    "samples_ab_5_to_10": [],
    "samples_ab_10_to_15": [],
    "samples_ab_15_to_20": [],
    "samples_ab_20_to_25": [],
    "samples_ab_25_to_30": [],
    "samples_ab_30_to_35": [],
    "samples_ab_35_to_40": [],
    "samples_ab_40_to_45": [
      "HG00733"
    ],
    "samples_gq_0_to_5": [],
    "samples_gq_5_to_10": [],
    "samples_gq_10_to_15": [],
    "samples_gq_15_to_20": [],
    "samples_gq_20_to_25": [],
    "samples_gq_25_to_30": [],
    "samples_gq_30_to_35": [],
    "samples_gq_35_to_40": [],
    "samples_gq_40_to_45": [],
    "samples_gq_45_to_50": [
      "NA19675"
    ],
    "samples_gq_50_to_55": [
      "NA19678"
    ],
    "samples_gq_55_to_60": [],
    "samples_gq_60_to_65": [],
    "samples_gq_65_to_70": [
      "NA19679"
    ],
    "samples_gq_70_to_75": [],
    "samples_gq_75_to_80": [],
    "samples_gq_80_to_85": [],
    "samples_gq_85_to_90": [],
    "samples_gq_90_to_95": [],
    "samples_no_call": [],
    "samples_num_alt_1": [
      "HG00733",
      "NA20872",
      "NA20878"
    ],
    "samples_num_alt_2": [
      "HG00731_1",
      "NA19675",
      "NA19678",
      "NA19679",
      "NA20870",
      "NA20874",
      "NA20875",
      "NA20876",
      "NA20881"
    ],
    "sortedTranscriptConsequences": [
      {
        "biotype": "protein_coding",
        "canonical": 1,
        "cdna_start": 1717,
        "cdna_end": 1717,
        "codons": "tCg/tTg",
        "gene_id": "ENSG00000188976",
        "gene_symbol": "NOC2L",
        "hgvsc": "ENST00000327044.6:c.1667C>T",
        "hgvsp": "ENSP00000317992.6:p.Ser556Leu",
        "transcript_id": "ENST00000327044",
        "amino_acids": "S/L",
        "lof_info": "INTRON_END:881781,EXON_END:881925,EXON_START:881782,DE_NOVO_DONOR_MES:-7.36719797135343,DE_NOVO_DONOR_PROB:0.261170618766552,DE_NOVO_DONOR_POS:-138,INTRON_START:881667,DE_NOVO_DONOR_MES_POS:-138,MUTANT_DONOR_MES:4.93863747168278",
        "polyphen_prediction": "benign",
        "protein_id": "ENSP00000317992",
        "protein_start": 556,
        "sift_prediction": "deleterious",
        "consequence_terms": [
          "missense_variant"
        ],
        "domains": [
          "hmmpanther:PTHR12687",
          "hmmpanther:PTHR12687",
          "Pfam_domain:PF03715",
          "Superfamily_domains:SSF48371"
        ],
        "major_consequence": "missense_variant",
        "category": "missense",
        "hgvs": "p.Ser556Leu",
        "major_consequence_rank": 11,
        "transcript_rank": 0
      },
      {
        "biotype": "retained_intron",
        "cdna_start": 3114,
        "cdna_end": 3114,
        "gene_id": "ENSG00000188976",
        "gene_symbol": "NOC2L",
        "hgvsc": "ENST00000477976.1:n.3114C>T",
        "transcript_id": "ENST00000477976",
        "consequence_terms": [
          "non_coding_transcript_exon_variant",
          "non_coding_transcript_variant"
        ],
        "major_consequence": "non_coding_transcript_exon_variant",
        "category": "other",
        "hgvs": "n.3114C>T",
        "major_consequence_rank": 22,
        "transcript_rank": 1
      },
      {
        "biotype": "retained_intron",
        "cdna_start": 523,
        "cdna_end": 523,
        "gene_id": "ENSG00000188976",
        "gene_symbol": "NOC2L",
        "hgvsc": "ENST00000483767.1:n.523C>T",
        "transcript_id": "ENST00000483767",
        "consequence_terms": [
          "non_coding_transcript_exon_variant",
          "non_coding_transcript_variant"
        ],
        "major_consequence": "non_coding_transcript_exon_variant",
        "category": "other",
        "hgvs": "n.523C>T",
        "major_consequence_rank": 22,
        "transcript_rank": 2
      }
    ],
    "start": 881627,
    "transcriptConsequenceTerms": [
      "missense_variant",
      "non_coding_transcript_exon_variant",
      "non_coding_transcript_variant"
    ],
    "transcriptIds": [
      "ENST00000327044",
      "ENST00000477976",
      "ENST00000483767"
    ],
    "variantId": "1-881627-G-A",
    "xpos": 1000881627,
    "xstart": 1000881627,
    "xstop": 1000881628
  }
}
```

