### PR TITLE
Join mega ref, clinvar, and hgmd tables into seqr mt schema

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_clinvar_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_clinvar_ht.py
@@ -1,12 +1,15 @@
-#!/usr/bin/env python3
-
-from hail_scripts.v02.utils.clinvar import download_and_import_latest_clinvar_vcf, CLINVAR_HT_PATH
+import hail as hl
+from hail_scripts.v02.utils.clinvar import download_and_import_latest_clinvar_vcf, CLINVAR_HT_PATH, CLINVAR_GOLD_STARS_LOOKUP
 from hail_scripts.v02.utils.hail_utils import write_ht
 
+
 for genome_version in ["37", "38"]:
+
     mt = download_and_import_latest_clinvar_vcf(genome_version)
 
     ht = mt.rows()
+    ht = ht.annotate(gold_stars=CLINVAR_GOLD_STARS_LOOKUP.get(hl.delimit(ht.info.CLNREVSTAT)))
+
     ht.describe()
 
     write_ht(ht, CLINVAR_HT_PATH.format(genome_version=genome_version))

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -115,8 +115,6 @@ CONFIG =  {
     'gnomad_genome_coverage': {
         '37': {
             'path': 'gs://gnomad-public/release/2.1/coverage/genomes/gnomad.genomes.r2.1.coverage.ht',
-            'select': {'AC': 'info.AC'},
-        },
     },
     'gnomad_exomes': {
         '37': {

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -18,7 +18,6 @@ class MatrixTableSampleSetError(Exception):
         super().__init__(message)
         self.missing_samples = missing_samples
 
-
 def GCSorLocalTarget(filename):
     target = gcs.GCSTarget if filename.startswith('gs://') else luigi.LocalTarget
     return target(filename)
@@ -84,8 +83,6 @@ class HailMatrixTableTask(luigi.Task):
             ht_stats['match'] = (ht_stats['matched_count']/ht_stats['total_count']) >= threshold
         return stats
 
-    
-
     def run_vep(mt, genome_version, runner='VEP'):
         runners = {
             'VEP': vep_runners.HailVEPRunner,
@@ -94,7 +91,6 @@ class HailMatrixTableTask(luigi.Task):
 
         return runners[runner]().run(mt, genome_version)
 
-      
     @staticmethod
     def subset_samples_and_variants(mt, subset_path):
         """
@@ -133,7 +129,7 @@ class HailMatrixTableTask(luigi.Task):
         :param remap_path: Path to a file with two columns 's' and 'seqr_id'
         :return: MatrixTable remapped and keyed to use seqr_id
         """
-        remap_ht = hl.import_table(remap_path, key ='s')
+        remap_ht = hl.import_table(remap_path, key='s')
         missing_samples = remap_ht.anti_join(mt.cols()).collect()
         remap_count = remap_ht.count()
 
@@ -160,7 +156,7 @@ class HailElasticSearchTask(luigi.Task):
     source_path = luigi.OptionalParameter(default=None)
     use_temp_loading_nodes = luigi.BoolParameter(default=True, description='Whether to use termporary loading nodes.')
     es_host = luigi.Parameter(description='ElasticSearch host.', default='localhost')
-    es_port = luigi.Parameter(description='ElasticSearch port.', default=9200)
+    es_port = luigi.IntParameter(description='ElasticSearch port.', default=9200)
     es_index = luigi.Parameter(description='ElasticSearch index.', default=None)
 
     def __init__(self, *args, **kwargs):

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -8,6 +8,12 @@ from hail_scripts.v02.utils.computed_fields import vep
 
 class SeqrSchema(BaseMTSchema):
 
+    def __init__(self, *args, ref_data, clinvar_data, hgmd_data, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._ref_data = ref_data
+        self._clinvar_data = clinvar_data
+        self._hgmd_data = hgmd_data
+
     @row_annotation()
     def vep(self):
         return self.mt.vep
@@ -86,6 +92,68 @@ class SeqrSchema(BaseMTSchema):
     def coding_gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences, only_coding_genes=True)
 
+    @row_annotation()
+    def cadd(self):
+        return self._ref_data[self.mt.row_key].cadd
+
+    @row_annotation()
+    def dbnsfp(self):
+        return self._ref_data[self.mt.row_key].dbnsfp
+
+    @row_annotation()
+    def gnomad_exomes(self):
+        return self._ref_data[self.mt.row_key].gnomad_exomes
+
+    @row_annotation()
+    def gnomad_exome_coverage(self):
+        return self._ref_data[self.mt.row_key].gnomad_exome_coverage
+
+    @row_annotation()
+    def gnomad_genomes(self):
+        return self._ref_data[self.mt.row_key].gnomad_genomes
+
+    @row_annotation()
+    def gnomad_genome_coverage(self):
+        return self._ref_data[self.mt.row_key].gnomad_genome_coverage
+
+    @row_annotation()
+    def eigen(self):
+        return self._ref_data[self.mt.row_key].eigen
+
+    @row_annotation()
+    def exac(self):
+        return self._ref_data[self.mt.row_key].exac
+
+    @row_annotation()
+    def g1k(self):
+        return self._ref_data[self.mt.row_key].g1k
+
+    @row_annotation()
+    def mpc(self):
+        return self._ref_data[self.mt.row_key].mpc
+
+    @row_annotation()
+    def primate_ai(self):
+        return self._ref_data[self.mt.row_key].primate_ai
+
+    @row_annotation()
+    def splice_ai(self):
+        return self._ref_data[self.mt.row_key].splice_ai
+
+    @row_annotation()
+    def topmed(self):
+        return self._ref_data[self.mt.row_key].topmed
+
+    @row_annotation()
+    def hgmd(self):
+        return hl.struct(**{'accession': self._hgmd_data[self.mt.row_key].rsid,
+                            'class': self._hgmd_data[self.mt.row_key].info.CLASS})
+
+    @row_annotation()
+    def clinvar(self):
+        return hl.struct(**{'allele_id': self._clinvar_data[self.mt.row_key].info.ALLELEID,
+                            'clinical_significance': hl.delimit(self._clinvar_data[self.mt.row_key].info.CLNSIG),
+                            'gold_stars': self._clinvar_data[self.mt.row_key].gold_stars})
 
 class SeqrVariantSchema(SeqrSchema):
 

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -18,12 +18,17 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
     """
     Inherits from a Hail MT Class to get helper function logic. Main logic to do annotations here.
     """
-    reference_mt_path = luigi.Parameter(description='Path to the matrix table storing the reference variants.')
+    reference_ht_path = luigi.Parameter(description='Path to the Hail table storing the reference variants.')
+    clinvar_ht_path = luigi.Parameter(description='Path to the Hail table storing the clinvar variants.')
+    hgmd_ht_path = luigi.Parameter(description='Path to the Hail table storing the hgmd variants.')
     sample_type = luigi.ChoiceParameter(choices=['WGS', 'WES'], description='Sample type, WGS or WES', var_type=str)
     validate = luigi.BoolParameter(default=True, description='Perform validation on the dataset.')
-    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV'], default='VARIANTS', description='VARIANTS or SV.')
-    remap_path = luigi.OptionalParameter(default=None, description="Path to a tsv file with two columns: s and seqr_id.")
-    subset_path = luigi.OptionalParameter(default=None, description="Path to a tsv file with one column of sample IDs: s.")
+    dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV'], default='VARIANTS',
+                                         description='VARIANTS or SV.')
+    remap_path = luigi.OptionalParameter(default=None,
+                                         description="Path to a tsv file with two columns: s and seqr_id.")
+    subset_path = luigi.OptionalParameter(default=None,
+                                          description="Path to a tsv file with one column of sample IDs: s.")
 
     def run(self):
         mt = self.import_vcf()
@@ -36,58 +41,63 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         mt = hl.split_multi(mt)
         mt = HailMatrixTableTask.run_vep(mt, self.genome_version, self.vep_runner)
 
-        mt = SeqrVariantSchema(mt).annotate_all(overwrite=True).select_annotated_mt()
+        ref_data = hl.read_table(self.reference_ht_path)
+        clinvar = hl.read_table(self.clinvar_ht_path)
+        hgmd = hl.read_table(self.hgmd_ht_path)
+
+        mt = SeqrVariantSchema(mt, ref_data=ref_data, clinvar_data=clinvar, hgmd_data=hgmd).annotate_all(
+            overwrite=True).select_annotated_mt()
 
         mt.describe()
         mt.write(self.output().path)
 
-    @staticmethod
-    def validate_mt(mt, genome_version, sample_type):
-        """
-        Validate the mt by checking against a list of common coding and non-coding variants given its
-        genome version. This validates genome_version, variants, and the reported sample type.
+@staticmethod
+def validate_mt(mt, genome_version, sample_type):
+    """
+    Validate the mt by checking against a list of common coding and non-coding variants given its
+    genome version. This validates genome_version, variants, and the reported sample type.
 
-        :param mt: mt to validate
-        :param genome_version: reference genome version
-        :param sample_type: WGS or WES
-        :return: True or Exception
-        """
-        sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
+    :param mt: mt to validate
+    :param genome_version: reference genome version
+    :param sample_type: WGS or WES
+    :return: True or Exception
+    """
+    sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
 
-        for name, stat in sample_type_stats.items():
-            logger.info('Table contains %i out of %i common %s variants.' %
-                        (stat['matched_count'], stat['total_count'], name))
+    for name, stat in sample_type_stats.items():
+        logger.info('Table contains %i out of %i common %s variants.' %
+                    (stat['matched_count'], stat['total_count'], name))
 
-        has_coding = sample_type_stats['coding']['match']
-        has_noncoding = sample_type_stats['noncoding']['match']
+    has_coding = sample_type_stats['coding']['match']
+    has_noncoding = sample_type_stats['noncoding']['match']
 
-        if not has_coding and not has_noncoding:
-            # No common variants detected.
+    if not has_coding and not has_noncoding:
+        # No common variants detected.
+        raise SeqrValidationError(
+            'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
+            'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
+        )
+    elif has_noncoding and not has_coding:
+        # Non coding only.
+        raise SeqrValidationError(
+            'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
+            'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
+        )
+    elif has_coding and not has_noncoding:
+        # Only coding should be WES.
+        if sample_type != 'WES':
             raise SeqrValidationError(
-                'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
-                'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
+                'Sample type validation error: dataset sample-type is specified as {} but appears to be '
+                'WGS because it contains many common coding variants'.format(sample_type)
             )
-        elif has_noncoding and not has_coding:
-            # Non coding only.
+    elif has_noncoding and has_coding:
+        # Both should be WGS.
+        if sample_type != 'WGS':
             raise SeqrValidationError(
-                'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
-                'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
+                'Sample type validation error: dataset sample-type is specified as {} but appears to be '
+                'WES because it contains many common non-coding variants'.format(sample_type)
             )
-        elif has_coding and not has_noncoding:
-            # Only coding should be WES.
-            if sample_type != 'WES':
-                raise SeqrValidationError(
-                    'Sample type validation error: dataset sample-type is specified as {} but appears to be '
-                    'WGS because it contains many common coding variants'.format(sample_type)
-                )
-        elif has_noncoding and has_coding:
-            # Both should be WGS.
-            if sample_type != 'WGS':
-                raise SeqrValidationError(
-                    'Sample type validation error: dataset sample-type is specified as {} but appears to be '
-                    'WES because it contains many common non-coding variants'.format(sample_type)
-                )
-        return True
+    return True
 
 
 class SeqrMTToESTask(HailElasticSearchTask):

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -51,53 +51,53 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
         mt.describe()
         mt.write(self.output().path)
 
-@staticmethod
-def validate_mt(mt, genome_version, sample_type):
-    """
-    Validate the mt by checking against a list of common coding and non-coding variants given its
-    genome version. This validates genome_version, variants, and the reported sample type.
+    @staticmethod
+    def validate_mt(mt, genome_version, sample_type):
+        """
+        Validate the mt by checking against a list of common coding and non-coding variants given its
+        genome version. This validates genome_version, variants, and the reported sample type.
 
-    :param mt: mt to validate
-    :param genome_version: reference genome version
-    :param sample_type: WGS or WES
-    :return: True or Exception
-    """
-    sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
+        :param mt: mt to validate
+        :param genome_version: reference genome version
+        :param sample_type: WGS or WES
+        :return: True or Exception
+        """
+        sample_type_stats = HailMatrixTableTask.sample_type_stats(mt, genome_version)
 
-    for name, stat in sample_type_stats.items():
-        logger.info('Table contains %i out of %i common %s variants.' %
-                    (stat['matched_count'], stat['total_count'], name))
+        for name, stat in sample_type_stats.items():
+            logger.info('Table contains %i out of %i common %s variants.' %
+                        (stat['matched_count'], stat['total_count'], name))
 
-    has_coding = sample_type_stats['coding']['match']
-    has_noncoding = sample_type_stats['noncoding']['match']
+        has_coding = sample_type_stats['coding']['match']
+        has_noncoding = sample_type_stats['noncoding']['match']
 
-    if not has_coding and not has_noncoding:
-        # No common variants detected.
-        raise SeqrValidationError(
-            'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
-            'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
-        )
-    elif has_noncoding and not has_coding:
-        # Non coding only.
-        raise SeqrValidationError(
-            'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
-            'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
-        )
-    elif has_coding and not has_noncoding:
-        # Only coding should be WES.
-        if sample_type != 'WES':
+        if not has_coding and not has_noncoding:
+            # No common variants detected.
             raise SeqrValidationError(
-                'Sample type validation error: dataset sample-type is specified as {} but appears to be '
-                'WGS because it contains many common coding variants'.format(sample_type)
+                'Genome version validation error: dataset specified as GRCh{genome_version} but doesn\'t contain '
+                'the expected number of common GRCh{genome_version} variants'.format(genome_version=genome_version)
             )
-    elif has_noncoding and has_coding:
-        # Both should be WGS.
-        if sample_type != 'WGS':
+        elif has_noncoding and not has_coding:
+            # Non coding only.
             raise SeqrValidationError(
-                'Sample type validation error: dataset sample-type is specified as {} but appears to be '
-                'WES because it contains many common non-coding variants'.format(sample_type)
+                'Sample type validation error: Dataset contains noncoding variants but is missing common coding '
+                'variants for GRCh{}. Please verify that the dataset contains coding variants.' .format(genome_version)
             )
-    return True
+        elif has_coding and not has_noncoding:
+            # Only coding should be WES.
+            if sample_type != 'WES':
+                raise SeqrValidationError(
+                    'Sample type validation error: dataset sample-type is specified as {} but appears to be '
+                    'WGS because it contains many common coding variants'.format(sample_type)
+                )
+        elif has_noncoding and has_coding:
+            # Both should be WGS.
+            if sample_type != 'WGS':
+                raise SeqrValidationError(
+                    'Sample type validation error: dataset sample-type is specified as {} but appears to be '
+                    'WES because it contains many common non-coding variants'.format(sample_type)
+                )
+        return True
 
 
 class SeqrMTToESTask(HailElasticSearchTask):


### PR DESCRIPTION
## Summary 
-Added reference data annotations to seqr loading pipeline which should allow for end to end runs. Tested full runs of SeqrVCFToMTTask locally and on the cloud. Spot checked results but will complete more thorough testing once reference schema is created. 
## Changes
-Added the gold_star annotations to the write_clinvar_ht script and ran it. https://console.cloud.google.com/dataproc/jobs/a85d98ed6a334547959e3a51760a9c98?project=seqr-project&organizationId=548622027621&supportedpurview=project&region=global&duration=P4D 
-Updated ES port parameter from a string to an int
-Removed unnecessary 'AD' field from gnomad genome coverage reference field selection
-Added all reference data annotations to seqr_mt_schema includes: cadd, dbnsfp, eigen, gnomad_exomes, gnomad_exomes_coverage, gnomad_genomes, gnomad_genomes_coverage, g1k, mpc, primate_ai, splice_ai, topmed, hgmd, clinvar
## To Do
-Create unit tests for new schema additions 
-Create reference schema and validate