### PR TITLE
Updated cluster submit to have pass through args

### DIFF
--- a/luigi_pipeline/load_dataset_v02.py
+++ b/luigi_pipeline/load_dataset_v02.py
@@ -116,7 +116,7 @@ def submit_load_dataset_to_es_job_v02(
         "%(executable)s",
         "--pyfiles %(pyfiles)s",
         "--files %(files)s",
-        "--args '%(task)s --local-scheduler'"
+        "%(task)s --local-scheduler"
         ])) % locals())
 
 


### PR DESCRIPTION
Cloudtools updated their submit script to have pass through args, --args and quotes are no longer necessary. 