### PR TITLE
Updated docId and null write fields in ES index

### DIFF
--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -29,7 +29,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         delete_index_before_exporting :bool = True,
         elasticsearch_write_operation :str = ELASTICSEARCH_INDEX,
         ignore_elasticsearch_write_errors :bool = False,
-        elasticsearch_mapping_id=None,
+        elasticsearch_mapping_id :str = "docId",
         field_name_to_elasticsearch_type_map=None,
         disable_doc_values_for_fields=(),
         disable_index_for_fields=(),
@@ -37,6 +37,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         func_to_run_after_index_exists=None,
         export_globals_to_index_meta=True,
         verbose=True,
+        write_null_es_fields :bool = False,
     ):
         """Create a new elasticsearch index to store the records in this table, and then export all records to it.
 
@@ -85,6 +86,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 (see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html)
             child_table (Table): if not None, records in this Table will be exported as children of records in the main Table.
             verbose (bool): whether to print schema and stats
+            write_null_es_fields (bool): whether to write fields that are null to the index
         """
 
         elasticsearch_config = {}
@@ -99,7 +101,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         if elasticsearch_write_operation is not None:
             elasticsearch_config["es.write.operation"] = elasticsearch_write_operation
 
-        if elasticsearch_write_operation in (ELASTICSEARCH_UPDATE, ELASTICSEARCH_UPSERT):
+        if elasticsearch_write_operation in (ELASTICSEARCH_UPDATE, ELASTICSEARCH_UPSERT) or write_null_es_fields:
             # see https://www.elastic.co/guide/en/elasticsearch/hadoop/master/spark.html#spark-sql-write
             # "By default, elasticsearch-hadoop will ignore null values in favor of not writing any field at all.
             # If updating/upserting, then existing field values may need to be overwritten with nulls

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -29,7 +29,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         delete_index_before_exporting :bool = True,
         elasticsearch_write_operation :str = ELASTICSEARCH_INDEX,
         ignore_elasticsearch_write_errors :bool = False,
-        elasticsearch_mapping_id :str = "docId",
+        elasticsearch_mapping_id=None,
         field_name_to_elasticsearch_type_map=None,
         disable_doc_values_for_fields=(),
         disable_index_for_fields=(),
@@ -37,7 +37,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         func_to_run_after_index_exists=None,
         export_globals_to_index_meta=True,
         verbose=True,
-        write_null_es_fields :bool = False,
+        write_null_values=False,
     ):
         """Create a new elasticsearch index to store the records in this table, and then export all records to it.
 
@@ -86,7 +86,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
                 (see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html)
             child_table (Table): if not None, records in this Table will be exported as children of records in the main Table.
             verbose (bool): whether to print schema and stats
-            write_null_es_fields (bool): whether to write fields that are null to the index
+            write_null_values (bool): whether to write fields that are null to the index
         """
 
         elasticsearch_config = {}
@@ -101,7 +101,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         if elasticsearch_write_operation is not None:
             elasticsearch_config["es.write.operation"] = elasticsearch_write_operation
 
-        if elasticsearch_write_operation in (ELASTICSEARCH_UPDATE, ELASTICSEARCH_UPSERT) or write_null_es_fields:
+        if elasticsearch_write_operation in (ELASTICSEARCH_UPDATE, ELASTICSEARCH_UPSERT) or write_null_values:
             # see https://www.elastic.co/guide/en/elasticsearch/hadoop/master/spark.html#spark-sql-write
             # "By default, elasticsearch-hadoop will ignore null values in favor of not writing any field at all.
             # If updating/upserting, then existing field values may need to be overwritten with nulls

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -41,7 +41,7 @@ class HailMatrixTableTask(luigi.Task):
                                                                                             'to annotate vep.')
 
     def requires(self):
-        # We need to exclude globs in source path since they aren't files.
+        # We only exclude globs in source path here so luigi does not check if the file exists
         return [VcfFile(filename=s) for s in self.source_paths if '*' not in s]
 
     def output(self):

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -102,6 +102,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
 class SeqrMTToESTask(HailElasticSearchTask):
     dest_file = luigi.Parameter()
+    es_index = luigi.Parameter(description='ElasticSearch index.', default=None)
+    write_es_null_fields = luigi.BoolParameter(default=True, description="Whether to write fields with null values to ES index")
 
     def __init__(self, *args, **kwargs):
         # TODO: instead of hardcoded index, generate from project_guid, etc.
@@ -115,9 +117,9 @@ class SeqrMTToESTask(HailElasticSearchTask):
         return GCSorLocalTarget(filename=self.dest_file)
 
     def run(self):
-        schema = SeqrVariantSchema(self.import_mt(),ref_data=None, clinvar_data=None, hgmd_data=None)
+        schema = SeqrVariantSchema(self.import_mt(), ref_data=None, clinvar_data=None, hgmd_data=None)
         row_table = schema.elasticsearch_row()
-        self.export_table_to_elasticsearch(row_table)
+        self.export_table_to_elasticsearch(row_table, self.write_es_null_fields)
 
         self.cleanup()
 

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -102,12 +102,10 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
 class SeqrMTToESTask(HailElasticSearchTask):
     dest_file = luigi.Parameter()
-    es_index = luigi.Parameter(description='ElasticSearch index.', default=None)
-    write_es_null_fields = luigi.BoolParameter(default=True, description="Whether to write fields with null values to ES index")
 
     def __init__(self, *args, **kwargs):
         # TODO: instead of hardcoded index, generate from project_guid, etc.
-        super().__init__(es_index='data', *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def requires(self):
         return [SeqrVCFToMTTask()]
@@ -119,7 +117,7 @@ class SeqrMTToESTask(HailElasticSearchTask):
     def run(self):
         schema = SeqrVariantSchema(self.import_mt(), ref_data=None, clinvar_data=None, hgmd_data=None)
         row_table = schema.elasticsearch_row()
-        self.export_table_to_elasticsearch(row_table, self.write_es_null_fields)
+        self.export_table_to_elasticsearch(row_table)
 
         self.cleanup()
 


### PR DESCRIPTION
## Summary
-Added docId as ES mapping ID to get rid of duplicate docs in index
-ES will skip writing  null fields so added write_null_es_fields arg to write out doc fields that have null values
-Updated error message for subsetting. Originally was printing out the number of samples in the vcf instead of the number of subset samples. This has been fixed. 
-Addressed glob patterns for importing vcfs so luigi requires will not fail