### PR TITLE
missing annotations

### DIFF
--- a/hail_scripts/v02/utils/computed_fields/variant_id.py
+++ b/hail_scripts/v02/utils/computed_fields/variant_id.py
@@ -63,7 +63,7 @@ def get_expr_for_start_pos(table):
 
 
 def get_expr_for_end_pos(table):
-    return table.locus.position + hl.len(get_expr_for_ref_allele(table))
+    return table.locus.position + hl.len(get_expr_for_ref_allele(table)) - 1
 
 
 def get_expr_for_variant_id(table, max_length=None):

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -18,6 +18,24 @@ class SeqrSchema(BaseMTSchema):
     def vep(self):
         return self.mt.vep
 
+    @row_annotation()
+    def rsid(self):
+        return self.mt.rsid
+
+    @row_annotation()
+    def filters(self):
+        return self.mt.filters
+
+    @row_annotation()
+    def aIndex(self):
+        return self.mt.a_index
+
+    @row_annotation()
+    def originalAltAlleles(self):
+        # TODO: This assumes we annotate `locus_old` in this code because `split_multi_hts` drops the proper `old_locus`.
+        # If we can get it to not drop it, we should revert this to `old_locus`
+        return variant_id.get_expr_for_variant_ids(self.mt.locus_old, self.mt.alleles_old)
+
     @row_annotation(name='sortedTranscriptConsequences', fn_require=vep)
     def sorted_transcript_consequences(self):
         return vep.get_expr_for_vep_sorted_transcript_consequences_array(self.mt.vep)

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -31,7 +31,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
     def run(self):
         mt = self.import_vcf()
-        mt = hl.split_multi_hts(mt)
+        mt = self.annotate_old_and_split_multi_hts(mt)
         if self.validate:
             self.validate_mt(mt, self.genome_version, self.sample_type)
         if self.remap_path:
@@ -49,6 +49,15 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
         mt.describe()
         mt.write(self.output().path, stage_locally=True)
+
+    def annotate_old_and_split_multi_hts(self, mt):
+        """
+        Saves the old allele and locus because while split_multi does this, split_multi_hts drops this. Will see if
+        we can add this to split_multi_hts and then this will be deprecated.
+        :return: mt that has pre-annotations
+        """
+        # Named `locus_old` instead of `old_locus` because split_multi_hts drops `old_locus`.
+        return hl.split_multi_hts(mt.annotate_rows(locus_old=mt.locus, alleles_old=mt.alleles))
 
     @staticmethod
     def validate_mt(mt, genome_version, sample_type):

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -19,7 +19,7 @@ class SeqrVCFToVariantMTTask(seqr_loading.SeqrVCFToMTTask):
 
     def run(self):
         mt = self.import_vcf()
-        mt = hl.split_multi_hts(mt)
+        mt = self.annotate_old_and_split_multi_hts(mt)
         if self.validate:
             self.validate_mt(mt, self.genome_version, self.sample_type)
         mt = HailMatrixTableTask.run_vep(mt, self.genome_version, self.vep_runner)


### PR DESCRIPTION
The long lost forgotten annotations, thanks to @mike-w-wilson validation. 

The important thing to note is `split_multi_hts` drops `old_locus` and `old_alleles` so we might see if we can remove that https://github.com/hail-is/hail/blob/e40fb8901ff40f3e29660cf4ef1193cd2be0f116/hail/python/hail/methods/statgen.py#L2251. In the mean time, we preannotate before splitting to generate the original alt alleles.



