### PR TITLE
add globals

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -13,14 +13,17 @@ import lib.hail_vep_runners as vep_runners
 
 logger = logging.getLogger(__name__)
 
+
 class MatrixTableSampleSetError(Exception):
     def __init__(self, message, missing_samples):
         super().__init__(message)
         self.missing_samples = missing_samples
 
+
 def GCSorLocalTarget(filename):
     target = gcs.GCSTarget if filename.startswith('gs://') else luigi.LocalTarget
     return target(filename)
+
 
 class VcfFile(luigi.Task):
     filename = luigi.Parameter()

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -19,20 +19,8 @@ class SeqrVCFToVariantMTTask(seqr_loading.SeqrVCFToMTTask):
     """
 
     def run(self):
-        mt = self.import_vcf()
-        mt = self.annotate_old_and_split_multi_hts(mt)
-        if self.validate:
-            self.validate_mt(mt, self.genome_version, self.sample_type)
-        mt = HailMatrixTableTask.run_vep(mt, self.genome_version, self.vep_runner)
-        # We're now adding ref data.
-        ref_data = hl.read_table(self.reference_ht_path)
-        clinvar = hl.read_table(self.clinvar_ht_path)
-        hgmd = hl.read_table(self.hgmd_ht_path)
-
-        mt = SeqrVariantSchema(mt, ref_data=ref_data, clinvar_data=clinvar, hgmd_data=hgmd).annotate_all(
-            overwrite=True).select_annotated_mt()
-
-        mt.write(self.output().path, stage_locally=True)
+        # We only want to use the Variant Schema.
+        self.read_vcf_write_mt(schema_cls=SeqrVariantSchema)
 
 
 class SeqrVCFToGenotypesMTTask(HailMatrixTableTask):


### PR DESCRIPTION
The Elastic Search index was missing some index metadata fields that are added from the matrix table globals through https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/hail_scripts/v02/utils/elasticsearch_client.py#L38.

The Missing and required annotations were `sourceFilePath`, `genomeVersion`, and `sampleType` from https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/00838a882d3e7df40194f915786802c26c9b4cd6/hail_scripts/v01/load_dataset_to_es.py#L309-L311. (I Don't think `dataset` is needed.)

This PR combines the logic that the plain and optimized tasks use to write a matrix table and ensures that the globals are annotated. When they are exported to ES (in the optimized, the variant mt is joined with the project-genotypes mt but the globals are retained) they are included in the index metadata.

# Local Check
Verified the variant mt written has 

```
Global fields:
    'sourceFilePath': str
    'genomeVersion': str
    'sampleType': str
----------------------------------------
Column fields:
    's': str
----------------------------------------
Row fields:
    'locus': locus<GRCh37>
    'alleles': array<str>
```

and the ES has 

<img width="1233" alt="Screen Shot 2019-08-21 at 1 20 05 PM" src="https://user-images.githubusercontent.com/615126/63453329-6be4eb80-c416-11e9-998c-acac6814a0e4.png">

FYI @hanars 