### PR TITLE
introduce row annotation skip and make hgmd optional

### DIFF
--- a/luigi_pipeline/lib/model/base_mt_schema.py
+++ b/luigi_pipeline/lib/model/base_mt_schema.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class RowAnnotationSkip(Exception):
+class RowAnnotationOmit(Exception):
     pass
 
 
@@ -62,8 +62,8 @@ def row_annotation(name=None, fn_require=None):
 
             try:
                 func_ret = func(self, *args, **kwargs)
-            # Do not annotate when RowAnnotationSkip raised.
-            except RowAnnotationSkip:
+            # Do not annotate when RowAnnotationOmit raised.
+            except RowAnnotationOmit:
                 return self
 
             annotation = {annotation_name: func_ret}

--- a/luigi_pipeline/lib/model/base_mt_schema.py
+++ b/luigi_pipeline/lib/model/base_mt_schema.py
@@ -6,6 +6,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class RowAnnotationSkip(Exception):
+    pass
+
+
 def row_annotation(name=None, fn_require=None):
     """
     Function decorator for methods in a subclass of BaseMTSchema.
@@ -56,7 +60,12 @@ def row_annotation(name=None, fn_require=None):
             if fn_require:
                 getattr(self, fn_require.__name__)()
 
-            func_ret = func(self, *args, **kwargs)
+            try:
+                func_ret = func(self, *args, **kwargs)
+            # Do not annotate when RowAnnotationSkip raised.
+            except RowAnnotationSkip:
+                return self
+
             annotation = {annotation_name: func_ret}
             self.mt = self.mt.annotate_rows(**annotation)
 

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -1,14 +1,14 @@
 
 import hail as hl
 
-from lib.model.base_mt_schema import BaseMTSchema, row_annotation
+from lib.model.base_mt_schema import BaseMTSchema, row_annotation, RowAnnotationSkip
 from hail_scripts.v02.utils.computed_fields import variant_id
 from hail_scripts.v02.utils.computed_fields import vep
 
 
 class SeqrSchema(BaseMTSchema):
 
-    def __init__(self, *args, ref_data, clinvar_data, hgmd_data, **kwargs):
+    def __init__(self, *args, ref_data, clinvar_data, hgmd_data=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._ref_data = ref_data
         self._clinvar_data = clinvar_data
@@ -164,6 +164,8 @@ class SeqrSchema(BaseMTSchema):
 
     @row_annotation()
     def hgmd(self):
+        if self._hgmd_data is None:
+            raise RowAnnotationSkip
         return hl.struct(**{'accession': self._hgmd_data[self.mt.row_key].rsid,
                             'class': self._hgmd_data[self.mt.row_key].info.CLASS})
 

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -1,7 +1,7 @@
 
 import hail as hl
 
-from lib.model.base_mt_schema import BaseMTSchema, row_annotation, RowAnnotationSkip
+from lib.model.base_mt_schema import BaseMTSchema, row_annotation, RowAnnotationOmit
 from hail_scripts.v02.utils.computed_fields import variant_id
 from hail_scripts.v02.utils.computed_fields import vep
 
@@ -165,7 +165,7 @@ class SeqrSchema(BaseMTSchema):
     @row_annotation()
     def hgmd(self):
         if self._hgmd_data is None:
-            raise RowAnnotationSkip
+            raise RowAnnotationOmit
         return hl.struct(**{'accession': self._hgmd_data[self.mt.row_key].rsid,
                             'class': self._hgmd_data[self.mt.row_key].info.CLASS})
 

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -20,7 +20,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
     """
     reference_ht_path = luigi.Parameter(description='Path to the Hail table storing the reference variants.')
     clinvar_ht_path = luigi.Parameter(description='Path to the Hail table storing the clinvar variants.')
-    hgmd_ht_path = luigi.Parameter(description='Path to the Hail table storing the hgmd variants.')
+    hgmd_ht_path = luigi.Parameter(default=None,
+                                   description='Path to the Hail table storing the hgmd variants.')
     sample_type = luigi.ChoiceParameter(choices=['WGS', 'WES'], description='Sample type, WGS or WES', var_type=str)
     validate = luigi.BoolParameter(default=True, description='Perform validation on the dataset.')
     dataset_type = luigi.ChoiceParameter(choices=['VARIANTS', 'SV'], default='VARIANTS',
@@ -46,7 +47,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
 
         ref_data = hl.read_table(self.reference_ht_path)
         clinvar = hl.read_table(self.clinvar_ht_path)
-        hgmd = hl.read_table(self.hgmd_ht_path)
+        # hgmd is optional.
+        hgmd = hl.read_table(self.hgmd_ht_path) if self.hgmd_ht_path else None
 
         mt = schema_cls(mt, ref_data=ref_data, clinvar_data=clinvar, hgmd_data=hgmd).annotate_all(
             overwrite=True).select_annotated_mt()


### PR DESCRIPTION
# Description
We want to make hgmd optional to run locally per @bw2's request.

# Implementation
- Introduces a RowAnnotationOmit exception (inspired by Airflow's https://github.com/apache/airflow/blob/master/airflow/exceptions.py#L73) that can be raised within an annotations function to skip an annotation altogether. 
- We omit the hgmd annotation altogether if no hgmd dataset is provided

