### PR TITLE
_SUCCESS check

### DIFF
--- a/luigi_pipeline/configs/optimized_configs/seqr-loading-local.cfg
+++ b/luigi_pipeline/configs/optimized_configs/seqr-loading-local.cfg
@@ -8,9 +8,6 @@ genome_version = 37
 validate=False
 source_paths = ["./tests/data/1kg_30variants.vcf.bgz"]
 dest_path = variants.mt
-reference_ht_path = gs://seqr-reference-data/GRCh37/all_reference_data/combined_reference_data_grch37.ht
-clinvar_ht_path = gs://seqr-reference-data/GRCh37/clinvar/clinvar.GRCh37.ht
-hgmd_ht_path = gs://seqr-reference-data-private/GRCh37/HGMD/hgmd_pro_2018.4_hg19_without_db_field.ht
 vep_runner = DUMMY
 
 [SeqrVCFToGenotypesMTTask]

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -2,6 +2,7 @@
 Tasks for Hail.
 """
 import logging
+import os
 
 import hail as hl
 import luigi
@@ -48,8 +49,13 @@ class HailMatrixTableTask(luigi.Task):
         return [VcfFile(filename=s) for s in self.source_paths if '*' not in s]
 
     def output(self):
-        # TODO: Look into checking against the _SUCCESS file in the mt.
         return GCSorLocalTarget(self.dest_path)
+
+    def complete(self):
+        # Complete is called by Luigi to check if the task is done and will skip if it is.
+        # By default it checks to see that the output exists, but we want to check for the
+        # _SUCCESS file to make sure it was not terminated halfway.
+        return GCSorLocalTarget(os.path.join(self.dest_path, '_SUCCESS')).exists()
 
     def run(self):
         # Overwrite to do custom transformations.

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -58,7 +58,7 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
                                  sampleType=self.sample_type)
 
         mt.describe()
-        mt.write(self.output().path, stage_locally=True)
+        mt.write(self.output().path, stage_locally=True, overwrite=True)
 
     def annotate_old_and_split_multi_hts(self, mt):
         """

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -43,7 +43,7 @@ class SeqrVCFToGenotypesMTTask(HailMatrixTableTask):
         mt = SeqrGenotypesSchema(mt).annotate_all(overwrite=True).select_annotated_mt()
 
         mt.describe()
-        mt.write(self.output().path)
+        mt.write(self.output().path, stage_locally=True, overwrite=True)
 
 
 class SeqrMTToESOptimizedTask(HailElasticSearchTask):


### PR DESCRIPTION
# Description
**Problem**: now that we checkpoint mt table to not redo work (e.g. if `variants.mt` exists, it will skip the task as complete), we run into issues if the task failed half way and the mt directory exists but is incomplete. In that case, we want to re-run the task.

# Design
This overrides the `complete` [method](https://luigi.readthedocs.io/en/stable/api/luigi.task.html#luigi.task.Task.complete) which by default checks if the output files exist. Instead, we check for the `_SUCCESS` file within the mt. Thus, if incomplete that file will not exist and it will re-run.

We also change the `mt.write` to override in case of incomplete tables.