### PR TITLE
min num shards

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -2,6 +2,7 @@
 Tasks for Hail.
 """
 import logging
+import math
 import os
 
 import hail as hl
@@ -231,5 +232,5 @@ class HailElasticSearchTask(luigi.Task):
     def _mt_num_shards(self, mt):
         # The greater of the user specified min shards and calculated based on the variants and samples
         denominator = 2147483519
-        calculated_num_shards = int((mt.count_rows() * mt.count_cols())/denominator)
+        calculated_num_shards = math.ceil((mt.count_rows() * mt.count_cols())/denominator)
         return max(self.es_index_min_num_shards, calculated_num_shards)

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -231,6 +231,6 @@ class HailElasticSearchTask(luigi.Task):
 
     def _mt_num_shards(self, mt):
         # The greater of the user specified min shards and calculated based on the variants and samples
-        denominator = 2147483519
+        denominator = 1.4*10**9
         calculated_num_shards = math.ceil((mt.count_rows() * mt.count_cols())/denominator)
         return max(self.es_index_min_num_shards, calculated_num_shards)

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -67,7 +67,7 @@ class SeqrMTToESOptimizedTask(HailElasticSearchTask):
         row_ht = genotypes_mt.rows().join(variants_mt.rows())
 
         row_ht = SeqrVariantsAndGenotypesSchema.elasticsearch_row(row_ht)
-        self.export_table_to_elasticsearch(row_ht)
+        self.export_table_to_elasticsearch(row_ht, self._mt_num_shards(genotypes_mt))
 
         self.cleanup()
 


### PR DESCRIPTION
# Description
Added logic for the number of shards: greater of user specified min_num_shards and a calculated value based on `(variants*samples)/2147483519` translated to `int((mt.count_rows() * mt.count_cols())/2147483519)`. 

NOTE: I don't know where `2147483519` comes from, it was just given to me, it's slightly less than 2^31. Should I use `(2^31 - 2^10) = 2147482624 ` just to make sure we have a larger num shards? 

# Testing
I tested this locally on the 1kg30 dataset (which as expected calculated the shards to be 0 since the data is so small), but have not run that formula on actual data like RGP. @mike-w-wilson we should do that to make sure that formula gives us what we expect. 

# Add on
Piggybacked on this PR to add the hail version to the global annotations --> ES metadata.

# TODO
Optional, but make the min_num_shards configurable in Airflow (I seriously doubt it will be used much though if the formula is accurate).