### PR TITLE
Determine ES mapping based on unkeyed table

### DIFF
--- a/hail_scripts/v02/utils/elasticsearch_utils.py
+++ b/hail_scripts/v02/utils/elasticsearch_utils.py
@@ -50,7 +50,7 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
         A dict that can be plugged in to an elasticsearch mapping as the value for "properties".
         (see https://www.elastic.co/guide/en/elasticsearch/guide/current/root-object.html)
     """
-    properties = _elasticsearch_mapping_for_type(table.row_value.dtype)["properties"]
+    properties = _elasticsearch_mapping_for_type(table.key_by().row_value.dtype)["properties"]
 
     if disable_doc_values_for_fields:
         logger.info("==> will disable doc values for %s", ", ".join(disable_doc_values_for_fields))


### PR DESCRIPTION
When exporting a table to Elasticsearch, the ES index is created (or updated) with a [mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html) based on the table's row value. However, the row value does not include key fields. So key fields are currently [dynamically mapped](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#_dynamic_mapping). This usually results in fields getting set to the [text](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html) type (and analyzed) when they would preferably be [keyword](https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html).

This changes the export function to determine the Elasticsearch mapping based on an unkeyed copy of the table. This maps the key fields consistently with the other row value fields.