### PR TITLE
Add support for locus types in Elasticsearch mapping

### DIFF
--- a/hail_scripts/v02/utils/elasticsearch_utils.py
+++ b/hail_scripts/v02/utils/elasticsearch_utils.py
@@ -26,6 +26,8 @@ def _elasticsearch_mapping_for_type(dtype):
         if isinstance(dtype.element_type, hl.tstruct):
             element_mapping["type"] = "nested"
         return element_mapping
+    if isinstance(dtype, hl.tlocus):
+        return {"type": "object", "properties": {"contig": {"type": "keyword"}, "position": {"type": "integer"}}}
     if dtype in HAIL_TYPE_TO_ES_TYPE_MAPPING:
         return {"type": HAIL_TYPE_TO_ES_TYPE_MAPPING[dtype]}
 


### PR DESCRIPTION
Currently, an Elasticsearch mapping can not be generated for a table that contains a [locus](https://hail.is/docs/0.2/types.html#hail.expr.types.tlocus) field.

For example, this code throws a `NotImplementedError`.
```python
import hail as hl
from hail_scripts.v02.utils.elasticsearch_utils import elasticsearch_schema_for_table

ds = hl.utils.range_table(10)
ds = ds.annotate(locus=hl.locus("1", ds.idx))

mapping = elasticsearch_schema_for_table(ds)
print(mapping)
```

This change adds support for the locus type. With this change, that example code outputs:
```
{'idx': {'type': 'integer'}, 'locus': {'type': 'object', 'properties': {'contig': {'type': 'keyword'}, 'position': {'type': 'integer'}}}}
```