### PR TITLE
Fixed POPMAX_OR_GLOBAL fallback value

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -200,7 +200,9 @@ def custom_gnomad_select_v2(ht):
     selects['AC'] = ht.freq[global_idx].AC
     selects['Hom'] = ht.freq[global_idx].homozygote_count
 
-    selects['AF_POPMAX_OR_GLOBAL'] = ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF
+    selects['AF_POPMAX_OR_GLOBAL'] = hl.cond(hl.is_defined(ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF),
+                                             ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF,
+                                             ht.freq[global_idx].AF)
     selects['FAF_AF'] = ht.faf[ht.globals.popmax_index_dict['gnomad']].faf95
     selects['Hemi'] = hl.cond(ht.locus.in_autosome_or_par(),
                               0, ht.freq[ht.globals.freq_index_dict['gnomad_male']].AC)
@@ -221,7 +223,8 @@ def custom_gnomad_select_v3(ht):
     selects['AC'] = ht.freq[global_idx].AC
     selects['Hom'] = ht.freq[global_idx].homozygote_count
 
-    selects['AF_POPMAX_OR_GLOBAL'] = ht.popmax.AF
+    selects['AF_POPMAX_OR_GLOBAL'] = hl.cond(hl.is_defined(ht.popmax.AF),
+                                             ht.popmax.AF, ht.freq[global_idx].AF)
     selects['FAF_AF'] = ht.faf[ht.globals.faf_index_dict['adj']].faf95
     selects['Hemi'] = hl.cond(ht.locus.in_autosome_or_par(),
                               0, ht.freq[ht.globals.freq_index_dict['adj_male']].AC)

--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -200,9 +200,7 @@ def custom_gnomad_select_v2(ht):
     selects['AC'] = ht.freq[global_idx].AC
     selects['Hom'] = ht.freq[global_idx].homozygote_count
 
-    selects['AF_POPMAX_OR_GLOBAL'] = hl.cond(hl.is_defined(ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF),
-                                             ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF,
-                                             ht.freq[global_idx].AF)
+    selects['AF_POPMAX_OR_GLOBAL'] = hl.or_else(ht.popmax[ht.globals.popmax_index_dict['gnomad']].AF, ht.freq[global_idx].AF)
     selects['FAF_AF'] = ht.faf[ht.globals.popmax_index_dict['gnomad']].faf95
     selects['Hemi'] = hl.cond(ht.locus.in_autosome_or_par(),
                               0, ht.freq[ht.globals.freq_index_dict['gnomad_male']].AC)
@@ -223,8 +221,7 @@ def custom_gnomad_select_v3(ht):
     selects['AC'] = ht.freq[global_idx].AC
     selects['Hom'] = ht.freq[global_idx].homozygote_count
 
-    selects['AF_POPMAX_OR_GLOBAL'] = hl.cond(hl.is_defined(ht.popmax.AF),
-                                             ht.popmax.AF, ht.freq[global_idx].AF)
+    selects['AF_POPMAX_OR_GLOBAL'] = hl.or_else(ht.popmax.AF, ht.freq[global_idx].AF)
     selects['FAF_AF'] = ht.faf[ht.globals.faf_index_dict['adj']].faf95
     selects['Hemi'] = hl.cond(ht.locus.in_autosome_or_par(),
                               0, ht.freq[ht.globals.freq_index_dict['adj_male']].AC)


### PR DESCRIPTION
This adds in a fallback to gnomAD global AF for a variant when POPMAX AF is not available. This was tested on the variant chr4-73258424-G-T in gnomAD v3 (4-74124141-G-T in gnomAD v2) where the missing value was discovered. 