### PR TITLE
add --use-seqr-loading-optimized-pipeline to optionally switch to optimized workflow

### DIFF
--- a/gcloud_dataproc/load_dataset.py
+++ b/gcloud_dataproc/load_dataset.py
@@ -65,7 +65,7 @@ def submit_load_dataset_to_es_job(
 
     # submit job
     run(" ".join(map(str, [
-        "./gcloud_dataproc/submit.py",
+        "python3 ./gcloud_dataproc/submit.py",
         "--hail-version 0.1",
         "--cluster %(dataproc_cluster_name)s",
         "hail_scripts/v01/load_dataset_to_es.py",

--- a/kubernetes/elasticsearch-sharded/es-namespace.yaml
+++ b/kubernetes/elasticsearch-sharded/es-namespace.yaml
@@ -1,4 +1,4 @@
-# isolates secrets and other objects between different environments (minikube, gcloud-dev, gcloud-prod, etc)
+# isolates secrets and other objects between different environments (gcloud-dev, gcloud-prod, etc)
 # see: https://kubernetes.io/blog/2015/08/using-kubernetes-namespaces-to-manage/
 apiVersion: v1
 kind: Namespace

--- a/kubernetes/kubectl_utils.py
+++ b/kubernetes/kubectl_utils.py
@@ -119,7 +119,7 @@ def get_pod_name(pod_name_label, deployment_target=None, pod_number=0):
 
     Args:
           pod_name_label (string): the "name" label of the pod
-          deployment_target (string): value from DEPLOYMENT_TARGETS - eg. "minikube", "gcloud-dev", etc.
+          deployment_target (string): value from DEPLOYMENT_TARGETS - eg. "gcloud-dev"
           pod_number (int): if there are multiple pods with the given label, it returns this one of the pods.
 
     Returns:
@@ -157,7 +157,7 @@ def run_in_pod(pod_name, command, deployment_target=None, errors_to_ignore=None,
     Args:
         pod_name (str): either the pod's "name" label (eg. 'phenotips' or 'nginx'), or the full pod name (eg. "phenotips-cdd4d7dc9-vgmjx")
         command (str): linux command to execute inside the pod
-        deployment_target (string): value from DEPLOYMENT_TARGETS - eg. "minikube", "gcloud-dev", etc.
+        deployment_target (string): value from DEPLOYMENT_TARGETS - eg. "gcloud-dev"
         errors_to_ignore (list): if the command's return code isn't in ok_return_codes, but its
             output contains one of the strings in this list, the bad return code will be ignored,
             and this function will return None. Otherwise, it raises a RuntimeException.

--- a/luigi_pipeline/load_dataset_v02_optimized.py
+++ b/luigi_pipeline/load_dataset_v02_optimized.py
@@ -298,12 +298,6 @@ def _compute_firewall_rule_name(k8s_cluster_name):
 
 
 def main():
-    if "-h" in sys.argv or "--help" in sys.argv:
-        run("python hail_scripts/v01/load_dataset_to_es.py -h")
-        print("====================================================================================================")
-        print("       NOTE: Any args not in the following list will be matched against args in the list above:")
-        print("====================================================================================================")
-
     os.chdir(os.path.join(os.path.dirname(__file__), ".."))
 
     # get command-line args


### PR DESCRIPTION
Running `load_dataset_v02` with the new `--use-seqr-loading-optimized-pipeline` flag should be equivalent to previously running `load_dataset_v02_optimized` (which this PR deletes). 
The only difference is `load_dataset_v02_optimized` had disabled the `_wait_for_data_nodes_state` method for unclear reasons:

https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/luigi_pipeline/load_dataset_v02_optimized.py#L143

I didn't add that to `load_dataset_v02 --use-seqr-loading-optimized-pipeline` but may need to if there are issues related to `_wait_for_data_nodes_state`. 
