### PR TITLE
Fixed subset message and added small optimization

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -136,9 +136,9 @@ class HailMatrixTableTask(luigi.Task):
             )
 
         mt = mt.semi_join_cols(subset_ht)
-        mt = mt.filter_rows((hl.agg.count_where(mt.GT.is_non_ref())) > 0)
+        mt = mt.filter_rows(hl.agg.any(mt.GT.is_non_ref()))
 
-        logger.info(f'Finished subsetting samples. Kept {anti_join_ht_count} '
+        logger.info(f'Finished subsetting samples. Kept {subset_count} '
                     f'out of {mt.count()} samples in vds')
         return mt
 


### PR DESCRIPTION
The subset message was printing the incorrect number. The filtering agg stops now as soon as it finds a non_ref GT instead of checking every GT in a row. 