### PR TITLE
add 37 coordinates

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -170,6 +170,18 @@ class HailMatrixTableTask(luigi.Task):
         logger.info(f'Remapped {remap_count} sample ids...')
         return mt
 
+    @staticmethod
+    def add_37_coordinates(mt):
+        """Annotates the GRCh38 MT with 37 coordinates using hail's built-in liftover
+        :param mt: MatrixTable from VCF
+        :return: MatrixTable annotated with GRCh37 coordinates
+        """
+        rg37 = hl.get_reference('GRCh37')
+        rg38 = hl.get_reference('GRCh38')
+        rg38.add_liftover('gs://hail-common/references/grch38_to_grch37.over.chain.gz', rg37)
+        mt = mt.annotate_rows(rg37_locus=hl.liftover(mt.locus, 'GRCh37'))
+        return mt
+
 
 class HailElasticSearchTask(luigi.Task):
     """

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -84,6 +84,12 @@ class SeqrSchema(BaseMTSchema):
     def xstop(self):
         return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt)) - 1
 
+    @row_annotation()
+    def rg37_locus(self):
+        if self.mt.locus.dtype.reference_genome.name != "GRCh38":
+            raise RowAnnotationOmit
+        return self.mt.rg37_locus
+
     @row_annotation(fn_require=sorted_transcript_consequences)
     def domains(self):
         return vep.get_expr_for_vep_protein_domains_set_from_sorted(

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -66,6 +66,8 @@ class SeqrVCFToMTTask(HailMatrixTableTask):
             mt = self.remap_sample_ids(mt, self.remap_path)
         if self.subset_path:
             mt = self.subset_samples_and_variants(mt, self.subset_path)
+        if self.genome_version == '38':
+            mt = self.add_37_coordinates(mt)
         mt = HailMatrixTableTask.run_vep(mt, self.genome_version, self.vep_runner, vep_config_json_path=self.vep_config_json_path)
 
         ref_data = hl.read_table(self.reference_ht_path)


### PR DESCRIPTION
This adds a `rg37_locus` to 38 callsets. Anything that does not lift is currently missing as you can't assign anything but a locus at this annotation. I could add in a `lifted_under` annotation or something if seqr needs a separate field indicating success. 